### PR TITLE
Add persistent minimap POI markers

### DIFF
--- a/src/data/world/pois.ts
+++ b/src/data/world/pois.ts
@@ -1,0 +1,61 @@
+/**
+ * @file src/data/world/pois.ts
+ * Defines static Points of Interest (POIs) that show up as map markers on
+ * both the minimap and full world map. Coordinates here are tile-based and
+ * align with the world map grid used in map generation.
+ */
+import { PointOfInterest } from '../../types';
+
+/**
+ * Points of Interest are intentionally light-weight: they provide a label,
+ * icon, and description that can be surfaced once the player uncovers the
+ * corresponding tile (or visits the area). Icons should be small enough to
+ * render inside tight grid cells.
+ */
+export const POIS: PointOfInterest[] = [
+  {
+    id: 'aralia_town_square',
+    name: 'Aralia Town Center',
+    description: 'Bustling square with markets and the central fountain.',
+    coordinates: { x: 14, y: 10 },
+    icon: '🏰',
+    category: 'settlement',
+    locationId: 'aralia_town_center',
+  },
+  {
+    id: 'forest_watch',
+    name: 'Forest Watch Path',
+    description: 'A guarded trail where scouts often keep watch.',
+    coordinates: { x: 15, y: 9 },
+    icon: '🌲',
+    category: 'wilderness',
+    locationId: 'forest_path',
+  },
+  {
+    id: 'hidden_spring',
+    name: 'Hidden Grove Spring',
+    description: 'A calm, secluded grove dotted with fireflies.',
+    coordinates: { x: 15, y: 11 },
+    icon: '🌿',
+    category: 'landmark',
+    locationId: 'hidden_grove',
+  },
+  {
+    id: 'old_ruins_gate',
+    name: 'Ancient Ruin Gate',
+    description: 'Crumbling archways that mark the ruined complex.',
+    coordinates: { x: 16, y: 10 },
+    icon: '🏛️',
+    category: 'ruin',
+    locationId: 'ancient_ruins_entrance',
+  },
+  {
+    id: 'echo_cavern',
+    name: 'Echoing Cave Mouth',
+    description: 'Cold air spills out of a jagged cave entrance.',
+    coordinates: { x: 15, y: 7 },
+    icon: '🕳️',
+    category: 'cave',
+    locationId: 'cave_entrance',
+  },
+];

--- a/src/types.ts
+++ b/src/types.ts
@@ -542,6 +542,40 @@ export interface MapData {
   tiles: MapTile[][];
 }
 
+export interface PointOfInterest {
+  /** Unique ID to reference this POI within UI elements. */
+  id: string;
+  /** Human readable name shown inside tooltips and legends. */
+  name: string;
+  /** Short description for hover tooltips. */
+  description: string;
+  /** World-map aligned coordinates (tile space, not pixels). */
+  coordinates: { x: number; y: number };
+  /** Emoji or small string icon used on the map surface. */
+  icon: string;
+  /** Category helps the legend group similar markers. */
+  category: 'settlement' | 'landmark' | 'ruin' | 'cave' | 'wilderness';
+  /** Optional link back to a formal Location entry. */
+  locationId?: string;
+}
+
+export interface MapMarker {
+  /** ID of the originating POI or generated marker. */
+  id: string;
+  /** Tile-space coordinates where the marker should render. */
+  coordinates: { x: number; y: number };
+  /** Icon rendered on both the minimap canvas and the large map grid. */
+  icon: string;
+  /** Text label shown in tooltips or alongside the icon. */
+  label: string;
+  /** Optional grouping used by the legend to style or describe the marker. */
+  category?: string;
+  /** Whether the marker should render as "known" (tile discovered or player present). */
+  isDiscovered: boolean;
+  /** Associated Location ID, if any, to aid tooltips. */
+  relatedLocationId?: string;
+}
+
 export enum QuestStatus {
   Active = 'Active',
   Completed = 'Completed',

--- a/src/utils/locationUtils.ts
+++ b/src/utils/locationUtils.ts
@@ -3,7 +3,7 @@
  * This file contains utility functions related to game locations,
  * such as determining dynamic NPCs.
  */
-import { Location } from '../types';
+import { Location, MapData, MapMarker, MapTile, PointOfInterest } from '../types';
 
 /**
  * Determines active dynamic NPCs for a given location based on its configuration.
@@ -28,4 +28,53 @@ export function determineActiveDynamicNpcsForLocation(locationId: string, locati
     return []; // Spawn chance failed, but config exists, so explicitly empty.
   }
   return null; // No dynamic NPC config for this location.
+}
+
+/**
+ * Determines whether tile-space coordinates are inside the currently loaded world map grid.
+ * Keeping this check centralized ensures both the minimap and full map avoid out-of-bounds
+ * reads when panning or rendering markers.
+ */
+export function isCoordinateWithinMap(coords: { x: number; y: number }, mapData: MapData | null): boolean {
+  if (!mapData) return false;
+  return coords.x >= 0 && coords.x < mapData.gridSize.cols && coords.y >= 0 && coords.y < mapData.gridSize.rows;
+}
+
+/**
+ * Convenience accessor for a specific map tile using world-map coordinates. All map rendering
+ * code should funnel through this helper so the bounds logic stays consistent and heavily
+ * commented in one place.
+ */
+export function getTileAtCoordinates(mapData: MapData | null, coords: { x: number; y: number }): MapTile | null {
+  if (!isCoordinateWithinMap(coords, mapData)) {
+    return null;
+  }
+  return mapData?.tiles[coords.y]?.[coords.x] ?? null;
+}
+
+/**
+ * Builds the concrete marker list used by both the minimap canvas and the main MapPane grid.
+ * Markers become "discovered" once their underlying tile is explored or if the player is
+ * currently standing on that tile. Keeping this derivation here avoids duplicating the same
+ * visibility rules in multiple components.
+ */
+export function buildPoiMarkers(pois: PointOfInterest[], mapData: MapData | null): MapMarker[] {
+  if (!mapData) return [];
+
+  return pois
+    .filter(poi => isCoordinateWithinMap(poi.coordinates, mapData))
+    .map(poi => {
+      const tile = getTileAtCoordinates(mapData, poi.coordinates);
+      const isDiscovered = Boolean(tile?.discovered || tile?.isPlayerCurrent);
+
+      return {
+        id: poi.id,
+        coordinates: poi.coordinates,
+        icon: poi.icon,
+        label: poi.name,
+        category: poi.category,
+        isDiscovered,
+        relatedLocationId: poi.locationId,
+      } satisfies MapMarker;
+    });
 }


### PR DESCRIPTION
## Summary
- add a reusable point-of-interest dataset and map marker helpers for world coordinates
- render discovered POI markers on both the minimap and full map with enhanced tooltips and legend entries
- keep the minimap persistently visible with clearer coordinate math and improved icon rendering

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924b9a9c9b4832fa9188e4258890b02)