### PR TITLE
Implement feat system and level-up framework

### DIFF
--- a/src/components/CharacterCreator/FeatSelection.tsx
+++ b/src/components/CharacterCreator/FeatSelection.tsx
@@ -1,9 +1,13 @@
 import React from 'react';
 import { Feat } from '../../types';
-import Tooltip from '../Tooltip';
+
+interface FeatOption extends Feat {
+  isEligible: boolean;
+  unmet: string[];
+}
 
 interface FeatSelectionProps {
-  availableFeats: Feat[];
+  availableFeats: FeatOption[];
   selectedFeatId?: string;
   onSelectFeat: (featId: string) => void;
   onBack?: () => void;
@@ -20,15 +24,17 @@ const FeatSelection: React.FC<FeatSelectionProps> = ({ availableFeats, selectedF
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 overflow-y-auto mb-6 p-2">
         {availableFeats.map((feat) => {
           const isSelected = feat.id === selectedFeatId;
+          const disabled = !feat.isEligible;
           return (
             <div
               key={feat.id}
-              onClick={() => onSelectFeat(feat.id)}
+              onClick={() => !disabled && onSelectFeat(feat.id)}
               className={`
                 p-4 rounded-lg border cursor-pointer transition-all duration-200 relative
-                ${isSelected
-                  ? 'bg-amber-900/40 border-amber-500 shadow-[0_0_15px_rgba(245,158,11,0.3)]'
-                  : 'bg-gray-800 border-gray-700 hover:border-gray-500 hover:bg-gray-750'
+                ${disabled ? 'bg-gray-900 border-gray-800 cursor-not-allowed opacity-70'
+                  : isSelected
+                    ? 'bg-amber-900/40 border-amber-500 shadow-[0_0_15px_rgba(245,158,11,0.3)]'
+                    : 'bg-gray-800 border-gray-700 hover:border-gray-500 hover:bg-gray-750'
                 }
               `}
             >
@@ -44,15 +50,34 @@ const FeatSelection: React.FC<FeatSelectionProps> = ({ availableFeats, selectedF
                   <div className="text-xs text-gray-500 mt-2">
                       <strong className="text-gray-400">Benefits:</strong>
                       <ul className="list-disc list-inside mt-1">
-                          {feat.benefits.abilityScoreIncrease && (
-                              <li>Ability Score Increase: {Object.entries(feat.benefits.abilityScoreIncrease).map(([k, v]) => `${k} +${v}`).join(', ')}</li>
+                          {feat.benefits.abilityScoreIncrease && Object.entries(feat.benefits.abilityScoreIncrease)
+                            .filter(([, value]) => (value || 0) > 0)
+                            .length > 0 && (
+                              <li>
+                                Ability Score Increase: {Object.entries(feat.benefits.abilityScoreIncrease)
+                                  .filter(([, value]) => (value || 0) > 0)
+                                  .map(([k, v]) => `${k} +${v}`).join(', ')}
+                              </li>
                           )}
                           {feat.benefits.speedIncrease && <li>Speed +{feat.benefits.speedIncrease} ft</li>}
                           {feat.benefits.initiativeBonus && <li>Initiative +{feat.benefits.initiativeBonus}</li>}
                           {feat.benefits.hpMaxIncreasePerLevel && <li>HP Max +{feat.benefits.hpMaxIncreasePerLevel} per level</li>}
                           {feat.benefits.resistance && <li>Resistance: {feat.benefits.resistance.join(', ')}</li>}
+                          {feat.benefits.skillProficiencies && <li>Skills: {feat.benefits.skillProficiencies.join(', ')}</li>}
+                          {feat.benefits.savingThrowProficiencies && <li>Saving Throws: {feat.benefits.savingThrowProficiencies.join(', ')}</li>}
                       </ul>
                   </div>
+              )}
+
+              {!feat.isEligible && (
+                <div className="text-xs text-red-400 mt-3">
+                  <strong>Unavailable:</strong>
+                  <ul className="list-disc list-inside">
+                    {feat.unmet.map(reason => (
+                      <li key={reason}>{reason}</li>
+                    ))}
+                  </ul>
+                </div>
               )}
 
               {isSelected && (

--- a/src/components/CharacterCreator/hooks/useCharacterAssembly.ts
+++ b/src/components/CharacterCreator/hooks/useCharacterAssembly.ts
@@ -17,7 +17,7 @@ import {
 } from '../../../types';
 import { SKILLS_DATA, WEAPONS_DATA, RACES_DATA, TIEFLING_LEGACIES } from '../../../constants';
 import { CharacterCreationState } from '../state/characterCreatorState'; 
-import { getAbilityModifierValue } from '../../../utils/characterUtils';
+import { getAbilityModifierValue, applyAllFeats } from '../../../utils/characterUtils';
 
 // --- Helper Functions for Character Assembly ---
 function validateAllSelectionsMade(state: CharacterCreationState): boolean {
@@ -221,7 +221,7 @@ export function useCharacterAssembly({ onCharacterCreate }: UseCharacterAssembly
     
     const castingProperties = assembleCastingProperties(currentState);
     
-    const assembledCharacter: PlayerCharacter = {
+    let assembledCharacter: PlayerCharacter = {
       id: `${Date.now()}-${(currentName || "char").replace(/\s+/g, '-')}`,
       name: currentName || "Adventurer",
       age: currentState.characterAge,
@@ -249,7 +249,12 @@ export function useCharacterAssembly({ onCharacterCreate }: UseCharacterAssembly
       selectedWarlockPatron: currentState.selectedWarlockPatron || undefined,
       racialSelections: currentState.racialSelections,
     };
-    
+
+    // Apply feat benefits after the baseline character is assembled so derived stats update.
+    if (assembledCharacter.feats && assembledCharacter.feats.length > 0) {
+      assembledCharacter = applyAllFeats(assembledCharacter, assembledCharacter.feats);
+    }
+
     return assembledCharacter;
 
   }, []);

--- a/src/data/feats/featsData.ts
+++ b/src/data/feats/featsData.ts
@@ -1,91 +1,138 @@
 import { Feat } from '../../types';
 
+/**
+ * Central feat catalogue. These entries intentionally focus on the
+ * mechanical pieces the character builder and level-up systems need
+ * (prerequisites + numerical benefits) rather than full rule text.
+ */
 export const FEATS_DATA: Feat[] = [
+  {
+    id: 'ability_score_improvement',
+    name: 'Ability Score Improvement',
+    description: 'Increase one ability score by 2, or two ability scores by 1 (to a max of 20).',
+    benefits: {
+      abilityScoreIncrease: {},
+    },
+  },
   {
     id: 'actor',
     name: 'Actor',
-    description: 'Skilled at mimicry and dramatics.',
+    description: 'Gain advantage on Performance and Deception checks made to adopt a persona and learn mimicry.',
+    prerequisites: { abilityScores: { Charisma: 13 } },
     benefits: {
-        abilityScoreIncrease: { Charisma: 1 },
-    }
+      abilityScoreIncrease: { Charisma: 1 },
+      skillProficiencies: ['deception', 'performance'],
+    },
   },
   {
     id: 'alert',
     name: 'Alert',
-    description: 'Always on the lookout for danger.',
+    description: 'You stay wary at all times, improving your initiative and awareness.',
     benefits: {
-        initiativeBonus: 5,
-    }
+      initiativeBonus: 5,
+    },
   },
   {
     id: 'athlete',
     name: 'Athlete',
-    description: 'Undergone extensive physical training.',
+    description: 'Conditioning improves your balance, agility, and stamina.',
     benefits: {
-        abilityScoreIncrease: { Strength: 1 }, // or Dexterity
-    }
+      abilityScoreIncrease: { Strength: 1, Dexterity: 1 },
+    },
   },
   {
     id: 'charger',
     name: 'Charger',
-    description: 'When you use your action to Dash, you can use a bonus action to make one melee weapon attack or to shove a creature.',
+    description: 'Harness your momentum to hit harder when dashing into melee.',
+    prerequisites: { minLevel: 4 },
+    benefits: {
+      abilityScoreIncrease: { Strength: 1 },
+    },
   },
   {
-      id: 'dungeon_delver',
-      name: 'Dungeon Delver',
-      description: 'Alert to the hidden traps and secret doors found in many dungeons.',
-      benefits: {
-          resistance: ['traps'], // Simplified for data
-      }
+    id: 'chef',
+    name: 'Chef',
+    description: 'Culinary training grants you hearty meals and better stamina.',
+    prerequisites: { minLevel: 4 },
+    benefits: {
+      abilityScoreIncrease: { Constitution: 1, Wisdom: 1 },
+      hpMaxIncreasePerLevel: 1,
+    },
   },
   {
-      id: 'durable',
-      name: 'Durable',
-      description: 'Hardy and resilient, you gain benefits when you roll Hit Dice.',
-      benefits: {
-          abilityScoreIncrease: { Constitution: 1 }
-      }
+    id: 'dungeon_delver',
+    name: 'Dungeon Delver',
+    description: 'Heightened senses help you avoid traps and hidden dangers underground.',
+    prerequisites: { minLevel: 4 },
+    benefits: {
+      resistance: ['traps'],
+      skillProficiencies: ['investigation', 'perception'],
+    },
   },
   {
-      id: 'healer',
-      name: 'Healer',
-      description: 'You are an able physician, allowing you to mend wounds quickly and get your allies back in the fight.',
+    id: 'durable',
+    name: 'Durable',
+    description: 'Hardy and resilient, you recover more health when resting.',
+    benefits: {
+      abilityScoreIncrease: { Constitution: 1 },
+      hpMaxIncreasePerLevel: 1,
+    },
   },
   {
-      id: 'lucky',
-      name: 'Lucky',
-      description: 'You have inexplicable luck that seems to kick in at just the right moment.',
+    id: 'healer',
+    name: 'Healer',
+    description: 'Battlefield medicine keeps your allies in the fight.',
+    benefits: {
+      abilityScoreIncrease: { Wisdom: 1 },
+      skillProficiencies: ['medicine'],
+    },
   },
   {
-      id: 'mobile',
-      name: 'Mobile',
-      description: 'You are exceptionally speedy and agile.',
-      benefits: {
-          speedIncrease: 10
-      }
+    id: 'lucky',
+    name: 'Lucky',
+    description: 'Fortune favors you when the stakes are high.',
   },
   {
-      id: 'observer',
-      name: 'Observer',
-      description: 'Quick to notice details of your environment.',
-      benefits: {
-          abilityScoreIncrease: { Intelligence: 1 }, // or Wisdom
-      }
+    id: 'mobile',
+    name: 'Mobile',
+    description: 'Exceptional speed and footwork let you dart around the battlefield.',
+    benefits: {
+      speedIncrease: 10,
+      abilityScoreIncrease: { Dexterity: 1 },
+    },
   },
   {
-      id: 'resilient',
-      name: 'Resilient',
-      description: 'Choose one ability score. You gain proficiency in saving throws using the chosen ability.',
-      benefits: {
-          abilityScoreIncrease: { Constitution: 1 } // Placeholder, usually requires choice
-      }
+    id: 'observant',
+    name: 'Observant',
+    description: 'Attentive eyes and ears sharpen your awareness of your surroundings.',
+    benefits: {
+      abilityScoreIncrease: { Intelligence: 1, Wisdom: 1 },
+      skillProficiencies: ['investigation', 'insight'],
+    },
   },
   {
-      id: 'tough',
-      name: 'Tough',
-      description: 'Your hit point maximum increases by an amount equal to twice your level when you gain this feat.',
-      benefits: {
-          hpMaxIncreasePerLevel: 2
-      }
-  }
+    id: 'resilient',
+    name: 'Resilient',
+    description: 'Bolster a saving throw of your choice.',
+    benefits: {
+      abilityScoreIncrease: { Constitution: 1 },
+      savingThrowProficiencies: ['Constitution'],
+    },
+  },
+  {
+    id: 'skilled',
+    name: 'Skilled',
+    description: 'You gain proficiency in three skills of your choice.',
+    benefits: {
+      skillProficiencies: ['athletics', 'perception', 'insight'],
+    },
+  },
+  {
+    id: 'tough',
+    name: 'Tough',
+    description: 'Each time you gain this feat, your hit point maximum increases by twice your level.',
+    benefits: {
+      hpMaxIncreasePerLevel: 2,
+    },
+  },
 ];

--- a/src/types.ts
+++ b/src/types.ts
@@ -134,6 +134,19 @@ export interface Feat {
   };
 }
 
+export interface FeatPrerequisiteContext {
+  level: number;
+  abilityScores: AbilityScores;
+  raceId?: string;
+  classId?: string;
+  knownFeats?: string[];
+}
+
+export interface LevelUpChoices {
+  abilityScoreIncreases?: Partial<AbilityScores>;
+  featId?: string;
+}
+
 export interface Race {
   id: string;
   name: string;
@@ -324,6 +337,7 @@ export interface PlayerCharacter {
   finalAbilityScores: AbilityScores;
   skills: Skill[];
   feats?: string[]; // IDs of selected feats
+  initiativeBonus?: number;
   hp: number;
   maxHp: number;
   armorClass: number;


### PR DESCRIPTION
## Summary
- expand feat definitions and selection UI with prerequisite awareness and clearer benefit displays
- add feat application during character assembly plus level-up utilities supporting ASIs and feat picks
- refine character creator back navigation to only clear the active step’s state and wire reducer handling for level-up choices

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924b9164a60832f98b6571406270d70)