### PR TITLE
Add AoE targeting AI and battle overlays

### DIFF
--- a/src/components/BattleMap/DamageNumberOverlay.tsx
+++ b/src/components/BattleMap/DamageNumberOverlay.tsx
@@ -1,7 +1,5 @@
-
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { DamageNumber } from '../../types/combat';
-import { motion, AnimatePresence } from 'framer-motion';
 import { TILE_SIZE_PX } from '../../config/mapConfig';
 
 interface DamageNumberOverlayProps {
@@ -9,34 +7,55 @@ interface DamageNumberOverlayProps {
 }
 
 const DamageNumberOverlay: React.FC<DamageNumberOverlayProps> = ({ damageNumbers }) => {
+  const [activeMap, setActiveMap] = useState<Record<string, boolean>>({});
+
+  // Trigger CSS transitions on the next frame for any newly added damage number.
+  useEffect(() => {
+    const toActivate: string[] = [];
+    damageNumbers.forEach(dn => {
+      if (!activeMap[dn.id]) {
+        toActivate.push(dn.id);
+      }
+    });
+
+    if (toActivate.length > 0) {
+      requestAnimationFrame(() => {
+        setActiveMap(prev => {
+          const next = { ...prev };
+          toActivate.forEach(id => {
+            next[id] = true;
+          });
+          return next;
+        });
+      });
+    }
+  }, [damageNumbers, activeMap]);
+
   return (
     <div className="absolute inset-0 pointer-events-none overflow-hidden" style={{ zIndex: 100 }}>
-      <AnimatePresence>
-        {damageNumbers.map((dn) => (
-          <motion.div
+      {damageNumbers.map((dn) => {
+        const active = !!activeMap[dn.id];
+        const baseLeft = dn.position.x * TILE_SIZE_PX + TILE_SIZE_PX / 2;
+        const baseTop = dn.position.y * TILE_SIZE_PX;
+        return (
+          <div
             key={dn.id}
-            initial={{
-                opacity: 1,
-                y: dn.position.y * TILE_SIZE_PX,
-                x: dn.position.x * TILE_SIZE_PX + (TILE_SIZE_PX / 2)
-            }}
-            animate={{
-                y: dn.position.y * TILE_SIZE_PX - 50,
-                opacity: 0
-            }}
-            exit={{ opacity: 0 }}
-            // Use the payload's duration so all callers share the same fade timing.
-            transition={{ duration: dn.duration / 1000, ease: "easeOut" }}
-            className={`absolute font-bold text-2xl drop-shadow-md flex items-center justify-center transform -translate-x-1/2`}
+            className="absolute font-bold text-2xl drop-shadow-md flex items-center justify-center select-none"
             style={{
-                 color: dn.type === 'heal' ? '#4ade80' : dn.type === 'miss' ? '#9ca3af' : '#ef4444',
-                 textShadow: '2px 2px 0 #000'
+              left: `${baseLeft}px`,
+              top: `${baseTop}px`,
+              transform: active ? 'translate(-50%, -42px)' : 'translate(-50%, 0px)',
+              opacity: active ? 0 : 1,
+              color: dn.type === 'heal' ? '#4ade80' : dn.type === 'miss' ? '#9ca3af' : '#ef4444',
+              textShadow: '2px 2px 0 #000',
+              transition: `transform ${dn.duration}ms ease-out, opacity ${dn.duration}ms ease-out`,
+              willChange: 'transform, opacity',
             }}
           >
             {dn.type === 'miss' ? 'MISS' : dn.value}
-          </motion.div>
-        ))}
-      </AnimatePresence>
+          </div>
+        );
+      })}
     </div>
   );
 };

--- a/src/components/BattleMapOverlay.tsx
+++ b/src/components/BattleMapOverlay.tsx
@@ -1,0 +1,129 @@
+import React, { useEffect, useState } from 'react';
+import { Ability, Animation, BattleMapData, CombatCharacter, DamageNumber } from '../types/combat';
+import DamageNumberOverlay from './BattleMap/DamageNumberOverlay';
+import { TILE_SIZE_PX } from '../config/mapConfig';
+import { getStatusEffectIcon } from '../utils/combatUtils';
+
+interface BattleMapOverlayProps {
+  mapData: BattleMapData;
+  characters: CombatCharacter[];
+  damageNumbers: DamageNumber[];
+  animations: Animation[];
+  aoePreview?: { center: { x: number; y: number }; affectedTiles: { x: number; y: number }[]; ability: Ability } | null;
+}
+
+/**
+ * Layered overlay for the tactical map. Aggregates floating numbers, buff/debuff
+ * badges, spell cues, and AoE previews using lightweight CSS transitions to
+ * avoid expensive animation libraries.
+ */
+const BattleMapOverlay: React.FC<BattleMapOverlayProps> = ({
+  mapData,
+  characters,
+  damageNumbers,
+  animations,
+  aoePreview,
+}) => {
+  const spellAnimations = animations.filter(anim => anim.type === 'spell_effect');
+  const [activeSpells, setActiveSpells] = useState<Record<string, boolean>>({});
+
+  useEffect(() => {
+    const newIds: string[] = [];
+    spellAnimations.forEach(anim => {
+      if (!activeSpells[anim.id]) newIds.push(anim.id);
+    });
+
+    if (newIds.length) {
+      requestAnimationFrame(() => {
+        setActiveSpells(prev => {
+          const next = { ...prev };
+          newIds.forEach(id => {
+            next[id] = true;
+          });
+          return next;
+        });
+      });
+    }
+  }, [spellAnimations, activeSpells]);
+
+  return (
+    <div
+      className="pointer-events-none absolute inset-0"
+      style={{
+        width: mapData.dimensions.width * TILE_SIZE_PX,
+        height: mapData.dimensions.height * TILE_SIZE_PX,
+        zIndex: 30,
+      }}
+    >
+      {/* Floating damage/heal numbers */}
+      <DamageNumberOverlay damageNumbers={damageNumbers} />
+
+      {/* Status icons on top of each character token */}
+      {characters.map((character) => (
+        <div
+          key={`status-${character.id}`}
+          className="absolute flex gap-1 items-center justify-center"
+          style={{
+            left: character.position.x * TILE_SIZE_PX + TILE_SIZE_PX / 2,
+            top: character.position.y * TILE_SIZE_PX - 6,
+            transform: 'translate(-50%, -100%)',
+            transition: 'opacity 200ms ease-out',
+            opacity: character.statusEffects.length ? 1 : 0,
+            zIndex: 40,
+          }}
+        >
+          {character.statusEffects.map((effect) => (
+            <span
+              key={`${character.id}-${effect.id}`}
+              className="text-xs font-semibold px-1 py-0.5 rounded-full bg-gray-900/80 border border-white/10"
+              title={`${effect.name} (${effect.duration}r)`}
+              style={{
+                color: effect.type === 'buff' ? '#a7f3d0' : effect.type === 'debuff' ? '#fca5a5' : '#e5e7eb',
+                transition: 'transform 150ms ease-out, opacity 150ms ease-out',
+              }}
+            >
+              {getStatusEffectIcon(effect)}
+            </span>
+          ))}
+        </div>
+      ))}
+
+      {/* Spell effect ripples */}
+      {spellAnimations.map((anim) => {
+        const positions: { x: number; y: number }[] = anim.data?.targetPositions || (anim.data?.targetPosition ? [anim.data.targetPosition] : []);
+        return positions.map((pos: { x: number; y: number }) => (
+          <div
+            key={`${anim.id}-${pos.x}-${pos.y}`}
+            className="absolute rounded-full bg-indigo-400/40 border border-indigo-300/40"
+            style={{
+              left: pos.x * TILE_SIZE_PX,
+              top: pos.y * TILE_SIZE_PX,
+              width: TILE_SIZE_PX,
+              height: TILE_SIZE_PX,
+              transform: activeSpells[anim.id] ? 'scale(1.05)' : 'scale(0.8)',
+              opacity: activeSpells[anim.id] ? 0.85 : 0,
+              transition: `opacity ${anim.duration}ms ease-out, transform ${anim.duration}ms ease-out`,
+            }}
+          />
+        ));
+      })}
+
+      {/* AoE preview outline to complement per-tile tinting */}
+      {aoePreview?.affectedTiles.map((pos) => (
+        <div
+          key={`aoe-${pos.x}-${pos.y}`}
+          className="absolute border-2 border-red-300/70 bg-red-400/10"
+          style={{
+            left: pos.x * TILE_SIZE_PX,
+            top: pos.y * TILE_SIZE_PX,
+            width: TILE_SIZE_PX,
+            height: TILE_SIZE_PX,
+            transition: 'opacity 120ms ease-out',
+          }}
+        />
+      ))}
+    </div>
+  );
+};
+
+export default BattleMapOverlay;

--- a/src/types/combat.ts
+++ b/src/types/combat.ts
@@ -115,6 +115,14 @@ export interface Ability {
   tags?: string[];
   targeting: TargetingType;
   range: number;
+  /**
+   * AoE metadata flattened onto the ability for quick inspection by AI/preview UIs.
+   * areaShape/areaSize mirror AreaOfEffect but remain optional so single-target
+   * abilities do not need to specify them. When present they should always align
+   * with D&D 5e templates (5 ft grid squares). size is expressed in tiles.
+   */
+  areaShape?: 'circle' | 'cone' | 'line' | 'square';
+  areaSize?: number;
   areaOfEffect?: AreaOfEffect;
   effects: AbilityEffect[];
   cooldown?: number;


### PR DESCRIPTION
## Summary
- add AoE evaluation paths and tactical positioning heuristics to the combat AI
- extend combat ability metadata and utilities to support area patterns and overlays
- add battle-map overlays for damage numbers, status icons, AoE previews, and spell effect cues, exposing animation events from the turn manager

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924e6745198832fb7f55b655007b8d6)