### PR TITLE
Implement village generator and minimap UI

### DIFF
--- a/src/components/MinimapComponent.tsx
+++ b/src/components/MinimapComponent.tsx
@@ -1,0 +1,97 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { MapData } from '../types';
+import { BIOMES } from '../constants';
+
+interface MinimapComponentProps {
+  mapData: MapData | null;
+  playerCoords: { x: number; y: number };
+  isVisible?: boolean;
+  onToggle?: () => void;
+  onPan?: (coords: { x: number; y: number }) => void;
+}
+
+const CANVAS_SIZE = 180;
+
+const MinimapComponent: React.FC<MinimapComponentProps> = ({ mapData, playerCoords, isVisible = true, onToggle, onPan }) => {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const [internalVisible, setInternalVisible] = useState<boolean>(isVisible);
+
+  useEffect(() => setInternalVisible(isVisible), [isVisible]);
+
+  const tileSize = useMemo(() => {
+    if (!mapData) return 0;
+    const maxDimension = Math.max(mapData.width, mapData.height);
+    return maxDimension ? CANVAS_SIZE / maxDimension : 0;
+  }, [mapData]);
+
+  useEffect(() => {
+    if (!internalVisible || !mapData || !canvasRef.current || tileSize === 0) return;
+    const ctx = canvasRef.current.getContext('2d');
+    if (!ctx) return;
+
+    canvasRef.current.width = CANVAS_SIZE;
+    canvasRef.current.height = CANVAS_SIZE;
+
+    ctx.fillStyle = '#0f172a';
+    ctx.fillRect(0, 0, CANVAS_SIZE, CANVAS_SIZE);
+
+    for (let y = 0; y < mapData.height; y++) {
+      for (let x = 0; x < mapData.width; x++) {
+        const tile = mapData.tiles[y][x];
+        const biome = BIOMES[tile.biomeId];
+        ctx.fillStyle = biome?.rgbaColor || '#334155';
+        ctx.fillRect(x * tileSize, y * tileSize, tileSize, tileSize);
+      }
+    }
+
+    // Player indicator
+    ctx.fillStyle = '#fbbf24';
+    ctx.beginPath();
+    ctx.arc((playerCoords.x + 0.5) * tileSize, (playerCoords.y + 0.5) * tileSize, Math.max(3, tileSize / 3), 0, Math.PI * 2);
+    ctx.fill();
+    ctx.strokeStyle = '#0b1722';
+    ctx.lineWidth = 1;
+    ctx.stroke();
+
+    ctx.strokeStyle = '#a16207';
+    ctx.lineWidth = 2;
+    ctx.strokeRect(0, 0, CANVAS_SIZE, CANVAS_SIZE);
+  }, [internalVisible, mapData, tileSize, playerCoords]);
+
+  const handleToggle = () => {
+    setInternalVisible(prev => !prev);
+    onToggle?.();
+  };
+
+  const handleClick = (event: React.MouseEvent<HTMLCanvasElement>) => {
+    if (!mapData || !canvasRef.current || tileSize === 0) return;
+    const rect = canvasRef.current.getBoundingClientRect();
+    const x = Math.floor((event.clientX - rect.left) / tileSize);
+    const y = Math.floor((event.clientY - rect.top) / tileSize);
+    if (x < 0 || y < 0 || x >= mapData.width || y >= mapData.height) return;
+    onPan?.({ x, y });
+  };
+
+  if (!internalVisible || !mapData) return (
+    <button className="px-3 py-1 text-xs rounded bg-amber-900 text-amber-100" onClick={handleToggle}>
+      Show Minimap
+    </button>
+  );
+
+  return (
+    <div className="flex flex-col gap-1 items-end">
+      <canvas
+        ref={canvasRef}
+        width={CANVAS_SIZE}
+        height={CANVAS_SIZE}
+        onClick={handleClick}
+        className="rounded-lg shadow-lg border border-amber-700 cursor-pointer"
+      />
+      <button className="px-3 py-1 text-xs rounded bg-amber-900 text-amber-100" onClick={handleToggle}>
+        Hide Minimap
+      </button>
+    </div>
+  );
+};
+
+export default MinimapComponent;

--- a/src/components/VillageScene.tsx
+++ b/src/components/VillageScene.tsx
@@ -1,0 +1,156 @@
+import React, { useEffect, useMemo, useRef } from 'react';
+import { describeBuilding, findBuildingAt, generateVillageLayout, VillageTileType } from '../services/villageGenerator';
+import { villageBuildingVisuals } from '../config/submapVisualsConfig';
+
+interface VillageSceneProps {
+  worldSeed: number;
+  worldX: number;
+  worldY: number;
+  biomeId: string;
+  onAction?: (action: any) => void;
+}
+
+const TILE_SIZE = 16;
+
+const baseTileFill: Record<VillageTileType, string> = {
+  grass: '#14532d',
+  path: villageBuildingVisuals.path.colors[0],
+  plaza: villageBuildingVisuals.plaza.colors[0],
+  market: villageBuildingVisuals.market.colors[1],
+  well: villageBuildingVisuals.well.colors[1],
+  guard_post: villageBuildingVisuals.guard_post.colors[0],
+  house_small: villageBuildingVisuals.house_small.colors[0],
+  house_medium: villageBuildingVisuals.house_medium.colors[0],
+  house_large: villageBuildingVisuals.house_large.colors[0],
+  shop_blacksmith: villageBuildingVisuals.shop_blacksmith.colors[0],
+  shop_general: villageBuildingVisuals.shop_general.colors[0],
+  shop_tavern: villageBuildingVisuals.shop_tavern.colors[0],
+  shop_temple: villageBuildingVisuals.shop_temple.colors[0]
+};
+
+const interactionLabels: Record<VillageTileType, string> = {
+  grass: 'Wander the Green',
+  path: 'Stroll the Lane',
+  plaza: 'Visit Central Plaza',
+  market: 'Browse Market Square',
+  well: 'Draw Water at the Well',
+  guard_post: 'Speak to the Guard',
+  house_small: 'Knock on Cottage Door',
+  house_medium: 'Visit Family Home',
+  house_large: 'Call on Manor',
+  shop_blacksmith: 'Visit Blacksmith',
+  shop_general: 'Visit General Store',
+  shop_tavern: 'Enter Tavern',
+  shop_temple: 'Enter Temple'
+};
+
+const VillageScene: React.FC<VillageSceneProps> = ({ worldSeed, worldX, worldY, biomeId, onAction }) => {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+
+  // Deterministically regenerate when world coordinates or seed change so
+  // villages stay anchored to their parent tile.
+  const layout = useMemo(
+    () => generateVillageLayout({ worldSeed, worldX, worldY, biomeId }),
+    [worldSeed, worldX, worldY, biomeId]
+  );
+
+  // Draw the deterministic canvas every time layout changes.
+  useEffect(() => {
+    if (!canvasRef.current) return;
+    const canvas = canvasRef.current;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    canvas.width = layout.width * TILE_SIZE;
+    canvas.height = layout.height * TILE_SIZE;
+
+    ctx.fillStyle = '#0b1722';
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+    // Render tile layer.
+    for (let y = 0; y < layout.height; y++) {
+      for (let x = 0; x < layout.width; x++) {
+        const tile = layout.tiles[y][x];
+        const baseColor = baseTileFill[tile] || '#0f172a';
+        ctx.fillStyle = baseColor;
+        ctx.fillRect(x * TILE_SIZE, y * TILE_SIZE, TILE_SIZE, TILE_SIZE);
+
+        // Add light texture based on visual pattern for variety
+        const visuals = villageBuildingVisuals[tile];
+        if (visuals?.pattern) {
+          ctx.strokeStyle = visuals.accent;
+          ctx.lineWidth = 1;
+          if (visuals.pattern === 'stripe') {
+            ctx.beginPath();
+            ctx.moveTo(x * TILE_SIZE, y * TILE_SIZE);
+            ctx.lineTo((x + 1) * TILE_SIZE, (y + 1) * TILE_SIZE);
+            ctx.stroke();
+          } else if (visuals.pattern === 'check') {
+            ctx.strokeRect(x * TILE_SIZE + 2, y * TILE_SIZE + 2, TILE_SIZE - 4, TILE_SIZE - 4);
+          } else if (visuals.pattern === 'dot') {
+            ctx.fillStyle = visuals.accent;
+            ctx.beginPath();
+            ctx.arc(x * TILE_SIZE + TILE_SIZE / 2, y * TILE_SIZE + TILE_SIZE / 2, 2, 0, Math.PI * 2);
+            ctx.fill();
+          }
+        }
+      }
+    }
+
+    // Draw road overlay to keep paths legible over buildings
+    ctx.strokeStyle = '#f8fafc';
+    ctx.lineWidth = 0.5;
+    layout.buildings.forEach(building => {
+      const { footprint } = building;
+      ctx.strokeRect(
+        footprint.x * TILE_SIZE,
+        footprint.y * TILE_SIZE,
+        footprint.width * TILE_SIZE,
+        footprint.height * TILE_SIZE
+      );
+    });
+  }, [layout]);
+
+  const handleClick = (event: React.MouseEvent<HTMLCanvasElement>) => {
+    if (!canvasRef.current) return;
+    const rect = canvasRef.current.getBoundingClientRect();
+    const x = Math.floor((event.clientX - rect.left) / TILE_SIZE);
+    const y = Math.floor((event.clientY - rect.top) / TILE_SIZE);
+    const building = findBuildingAt(layout, x, y);
+    const tileType: VillageTileType = building?.type || layout.tiles[y]?.[x] || 'grass';
+    const label = interactionLabels[tileType] || 'Investigate';
+
+    const payload = {
+      villageContext: {
+        worldX,
+        worldY,
+        biomeId,
+        buildingId: building?.id,
+        buildingType: tileType,
+        description: building ? describeBuilding(building, layout.personality) : 'A quiet corner of the village.'
+      }
+    };
+
+    onAction?.({ type: 'custom', label, payload });
+  };
+
+  return (
+    <div className="w-full h-full flex flex-col gap-2">
+      <div className="flex items-center justify-between text-amber-200 text-xs font-cinzel">
+        <span>
+          Village mood: {layout.personality.wealth} / {layout.personality.culture} / {layout.personality.biomeStyle}
+        </span>
+        <span>Population: {layout.personality.population}</span>
+      </div>
+      <canvas
+        ref={canvasRef}
+        width={layout.width * TILE_SIZE}
+        height={layout.height * TILE_SIZE}
+        className="w-full max-h-[70vh] rounded-lg border border-amber-700 shadow-inner bg-black"
+        onClick={handleClick}
+      />
+    </div>
+  );
+};
+
+export default VillageScene;

--- a/src/config/submapVisualsConfig.ts
+++ b/src/config/submapVisualsConfig.ts
@@ -133,3 +133,23 @@ export const defaultBiomeVisuals: BiomeVisuals = {
   seededFeatures: [],
   scatterFeatures: [{ icon: '?', density: 1 }],
 };
+
+/**
+ * Visual definitions for the village canvas system. Each entry bundles a
+ * palette and optional texture hints so the renderer can pick deterministic
+ * variety without hard-coding colors into the drawing logic.
+ */
+export const villageBuildingVisuals: Record<string, { colors: string[]; accent: string; pattern?: 'stripe' | 'check' | 'dot' }> = {
+  plaza: { colors: ['#f8fafc', '#e2e8f0', '#cbd5e1'], accent: '#94a3b8', pattern: 'check' },
+  path: { colors: ['#a16207', '#b45309', '#c08457'], accent: '#78350f', pattern: 'stripe' },
+  house_small: { colors: ['#facc15', '#fde047', '#fbbf24'], accent: '#92400e' },
+  house_medium: { colors: ['#f97316', '#fb923c', '#fdba74'], accent: '#7c2d12' },
+  house_large: { colors: ['#ef4444', '#f87171', '#fca5a5'], accent: '#991b1b', pattern: 'stripe' },
+  shop_blacksmith: { colors: ['#475569', '#334155', '#111827'], accent: '#f8fafc', pattern: 'dot' },
+  shop_general: { colors: ['#4ade80', '#22c55e', '#15803d'], accent: '#166534', pattern: 'check' },
+  shop_tavern: { colors: ['#8b5cf6', '#7c3aed', '#c084fc'], accent: '#4c1d95' },
+  shop_temple: { colors: ['#38bdf8', '#0ea5e9', '#67e8f9'], accent: '#0f172a', pattern: 'stripe' },
+  guard_post: { colors: ['#3b82f6', '#1d4ed8', '#1e40af'], accent: '#0ea5e9', pattern: 'check' },
+  market: { colors: ['#f472b6', '#f9a8d4', '#ec4899'], accent: '#9d174d', pattern: 'stripe' },
+  well: { colors: ['#38bdf8', '#0ea5e9', '#0284c7'], accent: '#0f172a', pattern: 'dot' }
+};

--- a/src/hooks/useGameActions.ts
+++ b/src/hooks/useGameActions.ts
@@ -307,6 +307,12 @@ export function useGameActions({
 
 
           case 'custom':
+            if (action.payload?.villageContext) {
+              const { buildingType, description } = action.payload.villageContext as { buildingType?: string; description?: string };
+              const detailText = description || `You take in the details of the ${buildingType ?? 'building'}.`;
+              addMessage(detailText, 'system');
+              break;
+            }
             if (action.label === 'Exit Village') {
               dispatch({ type: 'SET_GAME_PHASE', payload: GamePhase.PLAYING });
               addMessage('You leave the village and return to your journey.', 'system');

--- a/src/services/villageGenerator.ts
+++ b/src/services/villageGenerator.ts
@@ -1,0 +1,375 @@
+import { villageBuildingVisuals } from '../config/submapVisualsConfig';
+import { createSeededRandom } from '../utils/submapUtils';
+
+/**
+ * Deterministic village generation pipeline.
+ *
+ * Steps:
+ * 1. Seed an RNG using world coords + biome so the same tile always yields the same layout.
+ * 2. Roll a "personality" profile that influences population and wealth distributions.
+ * 3. Carve axial roads and winding side streets to avoid a strict grid.
+ * 4. Stamp civic core (plaza + well + market + guard posts) near the centre.
+ * 5. Place shops around the plaza with soft collision checks to keep lanes clear.
+ * 6. Scatter houses outward with distance bias so outskirts feel residential.
+ * 7. Return both a tile matrix and building footprints for hit-testing.
+ */
+
+export type VillageTileType =
+  | 'grass'
+  | 'path'
+  | 'plaza'
+  | 'market'
+  | 'well'
+  | 'guard_post'
+  | 'house_small'
+  | 'house_medium'
+  | 'house_large'
+  | 'shop_blacksmith'
+  | 'shop_general'
+  | 'shop_tavern'
+  | 'shop_temple';
+
+export interface VillageBuildingFootprint {
+  id: string;
+  type: VillageTileType;
+  footprint: { x: number; y: number; width: number; height: number };
+  color: string;
+  accent: string;
+}
+
+export interface VillagePersonality {
+  wealth: 'poor' | 'comfortable' | 'rich';
+  culture: 'stoic' | 'festive' | 'scholarly' | 'martial';
+  biomeStyle: 'temperate' | 'arid' | 'coastal' | 'swampy';
+  population: 'small' | 'medium' | 'large';
+}
+
+export interface VillageLayout {
+  width: number;
+  height: number;
+  tiles: VillageTileType[][];
+  buildings: VillageBuildingFootprint[];
+  personality: VillagePersonality;
+}
+
+interface GenerationOptions {
+  worldSeed: number;
+  worldX: number;
+  worldY: number;
+  biomeId: string;
+}
+
+const TILE_TYPES_PRIORITY: VillageTileType[] = [
+  'plaza',
+  'market',
+  'well',
+  'guard_post',
+  'shop_blacksmith',
+  'shop_general',
+  'shop_tavern',
+  'shop_temple',
+  'house_large',
+  'house_medium',
+  'house_small',
+  'path',
+  'grass'
+];
+
+const clamp = (value: number, min: number, max: number) => Math.max(min, Math.min(max, value));
+
+const pickColor = (type: VillageTileType, rng: () => number): { fill: string; accent: string; pattern?: 'stripe' | 'check' | 'dot' } => {
+  const visuals = villageBuildingVisuals[type] || villageBuildingVisuals.path;
+  const colorIndex = Math.floor(rng() * visuals.colors.length) % visuals.colors.length;
+  return { fill: visuals.colors[colorIndex], accent: visuals.accent, pattern: visuals.pattern };
+};
+
+const inferBiomeStyle = (biomeId: string): VillagePersonality['biomeStyle'] => {
+  if (biomeId === 'desert') return 'arid';
+  if (biomeId === 'ocean') return 'coastal';
+  if (biomeId === 'swamp') return 'swampy';
+  return 'temperate';
+};
+
+const rollPersonality = (rng: () => number, biomeId: string): VillagePersonality => {
+  const wealthRoll = rng();
+  const wealth: VillagePersonality['wealth'] = wealthRoll > 0.7 ? 'rich' : wealthRoll > 0.35 ? 'comfortable' : 'poor';
+
+  const cultureRoll = rng();
+  const culture: VillagePersonality['culture'] =
+    cultureRoll > 0.75 ? 'martial' : cultureRoll > 0.5 ? 'scholarly' : cultureRoll > 0.25 ? 'festive' : 'stoic';
+
+  const populationRoll = rng();
+  const population: VillagePersonality['population'] = populationRoll > 0.7 ? 'large' : populationRoll > 0.35 ? 'medium' : 'small';
+
+  return {
+    wealth,
+    culture,
+    biomeStyle: inferBiomeStyle(biomeId),
+    population
+  };
+};
+
+const createGrid = (width: number, height: number, defaultTile: VillageTileType): VillageTileType[][] => {
+  return Array.from({ length: height }, () => Array.from({ length: width }, () => defaultTile));
+};
+
+const carvePath = (tiles: VillageTileType[][], points: { x: number; y: number }[]) => {
+  points.forEach(({ x, y }) => {
+    if (tiles[y] && tiles[y][x]) {
+      tiles[y][x] = 'path';
+    }
+  });
+};
+
+const areaIsFree = (tiles: VillageTileType[][], x: number, y: number, width: number, height: number): boolean => {
+  for (let dy = 0; dy < height; dy++) {
+    for (let dx = 0; dx < width; dx++) {
+      const px = x + dx;
+      const py = y + dy;
+      if (!tiles[py] || !tiles[py][px]) return false;
+      const tile = tiles[py][px];
+      if (tile !== 'grass' && tile !== 'path') return false;
+    }
+  }
+  return true;
+};
+
+const stampBuilding = (
+  tiles: VillageTileType[][],
+  building: VillageBuildingFootprint,
+  plazaBoost = false
+) => {
+  const { footprint, type } = building;
+  for (let dy = 0; dy < footprint.height; dy++) {
+    for (let dx = 0; dx < footprint.width; dx++) {
+      const x = footprint.x + dx;
+      const y = footprint.y + dy;
+      if (!tiles[y] || typeof tiles[y][x] === 'undefined') continue;
+      // Plaza tiles keep highest priority to make the square obvious
+      if (plazaBoost && type === 'market') {
+        tiles[y][x] = 'plaza';
+      } else {
+        tiles[y][x] = type;
+      }
+    }
+  }
+};
+
+const getConnectionPath = (
+  start: { x: number; y: number },
+  target: { x: number; y: number }
+): { x: number; y: number }[] => {
+  const points: { x: number; y: number }[] = [];
+  let cx = start.x;
+  let cy = start.y;
+  while (cx !== target.x || cy !== target.y) {
+    if (cx !== target.x) cx += cx < target.x ? 1 : -1;
+    if (cy !== target.y) cy += cy < target.y ? 1 : -1;
+    points.push({ x: cx, y: cy });
+  }
+  return points;
+};
+
+const addWindingRoads = (tiles: VillageTileType[][], rng: () => number) => {
+  const height = tiles.length;
+  const width = tiles[0]?.length || 0;
+  // Lay subtle curvature so roads feel organic instead of perfectly orthogonal.
+  for (let y = 4; y < height; y += 6) {
+    const wobble = Math.floor(rng() * 3) - 1;
+    for (let x = 0; x < width; x++) {
+      const rowY = clamp(y + wobble, 1, height - 2);
+      if (tiles[rowY][x] === 'grass') tiles[rowY][x] = 'path';
+    }
+  }
+};
+
+export const generateVillageLayout = ({ worldSeed, worldX, worldY, biomeId }: GenerationOptions): VillageLayout => {
+  const width = 48;
+  const height = 32;
+  const biomeSeedText = `${biomeId}_village`;
+  const rng = createSeededRandom(worldSeed, { x: worldX, y: worldY }, biomeSeedText, 'village_rng');
+  const personality = rollPersonality(rng, biomeId);
+
+  const tiles = createGrid(width, height, 'grass');
+  const buildings: VillageBuildingFootprint[] = [];
+
+  const center = { x: Math.floor(width / 2), y: Math.floor(height / 2) };
+
+  // Carve main axial roads touching every edge to guarantee connectivity
+  carvePath(
+    tiles,
+    Array.from({ length: width }, (_, x) => ({ x, y: center.y }))
+  );
+  carvePath(
+    tiles,
+    Array.from({ length: height }, (_, y) => ({ x: center.x, y }))
+  );
+
+  // Winding secondary roads create neighborhoods and variety
+  addWindingRoads(tiles, rng);
+
+  // Central plaza anchors civic life
+  const plazaSize = 6;
+  const plazaTopLeft = { x: center.x - Math.floor(plazaSize / 2), y: center.y - Math.floor(plazaSize / 2) };
+  const plazaBuilding: VillageBuildingFootprint = {
+    id: 'plaza-core',
+    type: 'plaza',
+    footprint: { x: plazaTopLeft.x, y: plazaTopLeft.y, width: plazaSize, height: plazaSize },
+    ...pickColor('plaza', rng)
+  };
+  stampBuilding(tiles, plazaBuilding, true);
+  buildings.push(plazaBuilding);
+
+  // Well sits in the heart of the plaza, deterministic placement for player cues
+  const well: VillageBuildingFootprint = {
+    id: 'village-well',
+    type: 'well',
+    footprint: { x: center.x - 1, y: center.y - 1, width: 2, height: 2 },
+    ...pickColor('well', rng)
+  };
+  stampBuilding(tiles, well);
+  buildings.push(well);
+
+  // Market covers most of the plaza, leaving breathing room for paths
+  const market: VillageBuildingFootprint = {
+    id: 'market-square',
+    type: 'market',
+    footprint: { x: plazaTopLeft.x + 1, y: plazaTopLeft.y + 1, width: plazaSize - 2, height: plazaSize - 2 },
+    ...pickColor('market', rng)
+  };
+  stampBuilding(tiles, market);
+  buildings.push(market);
+
+  // Guard posts watch over northern and southern gates
+  const guardOffsets = [-1, 1];
+  guardOffsets.forEach((offset, idx) => {
+    const guard: VillageBuildingFootprint = {
+      id: `guard-post-${idx}`,
+      type: 'guard_post',
+      footprint: { x: center.x - 1, y: center.y + offset * (Math.floor(height / 2) - 3), width: 2, height: 2 },
+      ...pickColor('guard_post', rng)
+    };
+    stampBuilding(tiles, guard);
+    carvePath(tiles, getConnectionPath({ x: center.x, y: center.y }, { x: guard.footprint.x, y: guard.footprint.y }));
+    buildings.push(guard);
+  });
+
+  // Shops cluster close to the plaza for foot traffic
+  const shopTypes: VillageTileType[] = ['shop_blacksmith', 'shop_general', 'shop_tavern', 'shop_temple'];
+  shopTypes.forEach((type, idx) => {
+    const radius = 4 + idx;
+    const angle = rng() * Math.PI * 2;
+    const posX = clamp(Math.floor(center.x + Math.cos(angle) * radius), 2, width - 6);
+    const posY = clamp(Math.floor(center.y + Math.sin(angle) * radius), 2, height - 6);
+    const footprint = { x: posX, y: posY, width: 4, height: 3 };
+    if (!areaIsFree(tiles, footprint.x, footprint.y, footprint.width, footprint.height)) return;
+    const shop: VillageBuildingFootprint = {
+      id: `${type}-${idx}`,
+      type,
+      footprint,
+      ...pickColor(type, rng)
+    };
+    stampBuilding(tiles, shop);
+    carvePath(tiles, getConnectionPath({ x: shop.footprint.x, y: shop.footprint.y }, center));
+    buildings.push(shop);
+  });
+
+  // Residential districts radiate outward, size based on population / wealth
+  const houseBudget = personality.population === 'large' ? 22 : personality.population === 'medium' ? 16 : 10;
+  const wealthBias = personality.wealth === 'rich' ? 0.7 : personality.wealth === 'comfortable' ? 0.5 : 0.3;
+  const houseTypes: VillageTileType[] = ['house_large', 'house_medium', 'house_small'];
+
+  for (let i = 0; i < houseBudget; i++) {
+    const typeRoll = rng();
+    let chosenType: VillageTileType = 'house_small';
+    if (typeRoll > wealthBias + 0.2) chosenType = 'house_large';
+    else if (typeRoll > wealthBias - 0.1) chosenType = 'house_medium';
+
+    const dist = 8 + Math.floor(rng() * (Math.min(width, height) / 3));
+    const angle = rng() * Math.PI * 2;
+    const posX = clamp(Math.floor(center.x + Math.cos(angle) * dist), 1, width - 6);
+    const posY = clamp(Math.floor(center.y + Math.sin(angle) * dist), 1, height - 6);
+    const baseSize = chosenType === 'house_large' ? 5 : chosenType === 'house_medium' ? 4 : 3;
+    const footprint = { x: posX, y: posY, width: baseSize, height: baseSize - 1 };
+
+    if (!areaIsFree(tiles, footprint.x, footprint.y, footprint.width, footprint.height)) continue;
+
+    const house: VillageBuildingFootprint = {
+      id: `${chosenType}-${i}`,
+      type: chosenType,
+      footprint,
+      ...pickColor(chosenType, rng)
+    };
+    stampBuilding(tiles, house);
+    carvePath(tiles, getConnectionPath({ x: footprint.x, y: footprint.y }, center));
+    buildings.push(house);
+  }
+
+  // Ensure tile priority is respected by normalising overlapping placements
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      const tile = tiles[y][x];
+      // fallback to plaza for inner square if overwritten by later steps
+      if (x >= plazaTopLeft.x && x < plazaTopLeft.x + plazaSize && y >= plazaTopLeft.y && y < plazaTopLeft.y + plazaSize) {
+        tiles[y][x] = tile === 'path' ? 'path' : tile;
+        continue;
+      }
+      const idx = TILE_TYPES_PRIORITY.indexOf(tile);
+      if (idx === -1) tiles[y][x] = 'grass';
+    }
+  }
+
+  return {
+    width,
+    height,
+    tiles,
+    buildings,
+    personality
+  };
+};
+
+/**
+ * Helper that produces a building info object for UI layers based on tile
+ * content. Canvas hit-testing in the VillageScene asks the generator for the
+ * top-most building that occupies a tile so interactions stay deterministic.
+ */
+export const findBuildingAt = (layout: VillageLayout, x: number, y: number): VillageBuildingFootprint | undefined => {
+  return layout.buildings.find(b => {
+    const { footprint } = b;
+    return x >= footprint.x && x < footprint.x + footprint.width && y >= footprint.y && y < footprint.y + footprint.height;
+  });
+};
+
+/**
+ * Simple deterministic utility for choosing a description string without
+ * requiring any additional type imports. This keeps the generator entirely
+ * self-contained and usable by both UI and gameplay hooks.
+ */
+export const describeBuilding = (building: VillageBuildingFootprint, personality: VillagePersonality): string => {
+  const cultureFlavor: Record<VillagePersonality['culture'], string> = {
+    stoic: 'practical lines and modest decor',
+    festive: 'banners and ribbons fluttering in the breeze',
+    scholarly: 'neatly painted signage and tidy facades',
+    martial: 'reinforced shutters and watchful eyes'
+  };
+
+  const typeName: Record<VillageTileType, string> = {
+    grass: 'Open Ground',
+    path: 'Path',
+    plaza: 'Central Plaza',
+    market: 'Market Square',
+    well: 'Village Well',
+    guard_post: 'Guard Post',
+    house_small: 'Small House',
+    house_medium: 'Family Home',
+    house_large: 'Estate House',
+    shop_blacksmith: 'Blacksmith',
+    shop_general: 'General Store',
+    shop_tavern: 'Tavern',
+    shop_temple: 'Temple'
+  };
+
+  const wealthFlavor = personality.wealth === 'rich' ? 'well-kept and prosperous' : personality.wealth === 'comfortable' ? 'orderly and welcoming' : 'weathered but lively';
+
+  return `${typeName[building.type]} with ${cultureFlavor[personality.culture]}; the settlement feels ${wealthFlavor}.`;
+};

--- a/src/state/reducers/uiReducer.ts
+++ b/src/state/reducers/uiReducer.ts
@@ -46,6 +46,11 @@ export function uiReducer(state: GameState, action: AppAction): Partial<GameStat
     case 'TOGGLE_MAP_VISIBILITY':
       return { isMapVisible: !state.isMapVisible, isSubmapVisible: false, isDevMenuVisible: false, isGeminiLogViewerVisible: false, characterSheetModal: { isOpen: false, character: null }, isDiscoveryLogVisible: false, isGlossaryVisible: false, selectedGlossaryTermForModal: undefined, isPartyOverlayVisible: false, isNpcTestModalVisible: false, isLogbookVisible: false, isGameGuideVisible: false, merchantModal: { ...state.merchantModal, isOpen: false } };
 
+    case 'TOGGLE_MINIMAP_VISIBILITY': {
+      const nextVisibility = !(state as any).isMinimapVisible;
+      return { ...(state as any), isMinimapVisible: nextVisibility } as Partial<GameState>;
+    }
+
     case 'TOGGLE_SUBMAP_VISIBILITY':
       return { isSubmapVisible: !state.isSubmapVisible, isMapVisible: false, isDevMenuVisible: false, isGeminiLogViewerVisible: false, characterSheetModal: { isOpen: false, character: null }, isDiscoveryLogVisible: false, isGlossaryVisible: false, selectedGlossaryTermForModal: undefined, isPartyOverlayVisible: false, isNpcTestModalVisible: false, isLogbookVisible: false, isGameGuideVisible: false, merchantModal: { ...state.merchantModal, isOpen: false } };
       

--- a/src/state/reducers/worldReducer.ts
+++ b/src/state/reducers/worldReducer.ts
@@ -7,8 +7,12 @@ import { AppAction } from '../actionTypes';
 
 export function worldReducer(state: GameState, action: AppAction): Partial<GameState> {
   switch (action.type) {
-    case 'SET_MAP_DATA':
-      return { mapData: action.payload };
+    case 'SET_MAP_DATA': {
+      const minimapFocus = action.payload
+        ? { x: Math.floor((action.payload as any).width / 2) || 0, y: Math.floor((action.payload as any).height / 2) || 0 }
+        : (state as any).minimapFocus;
+      return { mapData: action.payload, minimapFocus } as Partial<GameState>;
+    }
 
     case 'UPDATE_INSPECTED_TILE_DESCRIPTION':
       return {


### PR DESCRIPTION
## Summary
- add a deterministic village generation service with expanded building types and visual palettes
- render new VillageScene canvas with interactive building clicks and village personality hints
- introduce a reusable minimap component plus supporting seeded RNG utilities and visibility state

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924e681e32c832f8f610af26ec9c494)