### PR TITLE
Add UI visuals and refresh documentation

### DIFF
--- a/docs/FEATURES_TODO.md
+++ b/docs/FEATURES_TODO.md
@@ -30,8 +30,7 @@ This file tracks planned features, enhancements, and tasks for the Aralia RPG pr
     *   **[TODO]** Gaining new abilities/spells upon level-up.
     *   **[TODO]** Improving stats or choosing feats.
 *   **Feat System**:
-    *   **[TODO]** Integrate feats as part of character creation and progression.
-    *   *(Note: The 'Versatile' trait for Humans is currently descriptive; no mechanical feat system is implemented yet.)*
+    *   **[TODO]** Integrate feats as part of character creation and progression. See dedicated section below.
 *   **Economy System**:
     *   **[DONE]** Introduce currency (PP, GP, EP, SP, CP).
     *   **[DONE]** Implement Merchant interface with buying/selling.
@@ -47,6 +46,15 @@ This file tracks planned features, enhancements, and tasks for the Aralia RPG pr
 *   **Character Age in Creation**:
     *   **[TODO]** Add Age selection to Character Creation.
     *   **[TODO]** Define and display logical age ranges for each race.
+
+### Feat System
+
+*   **Current State**:
+    *   The Human "Versatile" trait describes an extra feat, but no mechanical feat selection or application pipeline exists.
+*   **Implementation Steps**:
+    *   Define structured feat data in `src/data/feats/` (including prerequisites, benefits, and usage limits) and aggregate exports in `src/constants.ts`.
+    *   Create a `FeatSelection` UI component for the character creator to surface eligible feats, enforce prerequisites, and capture the player's choice.
+    *   Integrate feat effects into character assembly so selected feats adjust derived stats, proficiencies, or abilities across combat and exploration systems.
 
 ## World & Exploration
 
@@ -102,7 +110,7 @@ This file tracks planned features, enhancements, and tasks for the Aralia RPG pr
 *   **Accessibility**:
     *   **[ONGOING]** ARIA implementations, keyboard navigation.
 *   **Scene Visuals**:
-    *   **[PAUSED]** `ImagePane` component exists, but image generation is currently disabled to manage API quotas.
+    *   **[PAUSED]** `ImagePane` component exists, but image generation is currently disabled to manage API quotas; scene panels rely on canvas or textual renderings until quota-friendly image generation is re-enabled.
 *   **Tooltips for Keywords**:
     *   **[DONE]** Implemented clickable/hoverable tooltips for game terms.
 *   **Submap Display**:

--- a/docs/PROJECT_OVERVIEW.README.md
+++ b/docs/PROJECT_OVERVIEW.README.md
@@ -14,6 +14,7 @@ Welcome to the main documentation hub for the Aralia RPG project. This document 
 *   **Tactical Battle Map**: A procedural, grid-based combat system featuring a D&D 5e-style action economy for tactical encounters.
 *   **Developer Mode**: Includes a "dummy character" to bypass character creation for rapid testing and a developer menu for quick actions like save/load.
 *   **Save/Load System**: Persists game state to the browser's Local Storage.
+*   **Scene Visuals (Paused)**: An `ImagePane.tsx` component exists for scene imagery, but image generation is currently disabled to manage external API quotas. Village and exploration scenes rely on canvas/grid renderings instead of fetched art.
 
 ## 2. Technology Stack & Architecture
 

--- a/docs/README_INDEX.md
+++ b/docs/README_INDEX.md
@@ -104,7 +104,6 @@ This file serves as a central index for all README documentation within the Aral
 *   **`src/components/MapPane.README.md`**: Documents the `MapPane.tsx` component.
 *   **`src/components/SubmapPane.README.md`**: Documents the `SubmapPane.tsx` component.
 *   **`src/components/Tooltip.README.md`**: Explains the reusable `Tooltip.tsx` component.
-*   **`src/components/GlossaryTooltip.README.md`**: Explains the `GlossaryTooltip.tsx` component.
 *   **`src/components/PartyPane.README.md`**: Details the `PartyPane.tsx` component.
 *   **`src/components/PartyOverlay.README.md`**: Details the `PartyOverlay.tsx` component.
 *   **`src/components/CharacterSheetModal.README.md`**: Documents the `CharacterSheetModal.tsx` component.
@@ -116,11 +115,11 @@ This file serves as a central index for all README documentation within the Aral
 *   **`src/components/GlossaryDisplay.README.md`**: Details the `GlossaryDisplay.tsx` component.
 *   **`src/components/DevMenu.README.md`**: Explains the `DevMenu.tsx` component.
 *   **`src/components/GeminiLogViewer.README.md`**: Documents the `GeminiLogViewer.tsx` component.
-*   **`src/components/DiscoveryLogPane.README.md`**: Details the `DiscoveryLogPane.tsx` component.
 *   **`src/components/SpellbookOverlay.README.md`**: Documents the new `SpellbookOverlay.tsx` component.
 *   **`src/components/LogbookPane.README.md`**: Documents the `LogbookPane.tsx` component.
 *   **`src/components/LoadingSpinner.README.md`**: Documents the `LoadingSpinner.tsx` component.
 *   **`src/components/WorldPane.README.md`**: Documents the `WorldPane.tsx` component.
+*   **`src/components/VillageScene.README.md`**: Describes the canvas-based village scene experience and current limitations.
 
 
 ### Services (`src/services/`)

--- a/docs/images/battle-map.svg
+++ b/docs/images/battle-map.svg
@@ -1,0 +1,40 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="900" height="540" viewBox="0 0 900 540" role="img" aria-label="Battle map grid with UI overlays">
+  <defs>
+    <style>
+      .bg { fill: #f0f7f0; stroke: #9cc59c; stroke-width: 4; }
+      .grid { fill: #d8e8d8; stroke: #7aa57a; stroke-width: 2; }
+      .token { fill: #fff; stroke: #3c6b3c; stroke-width: 3; }
+      .enemy { fill: #f8d7d7; stroke: #b84c4c; stroke-width: 3; }
+      .panel { fill: #ffffff; stroke: #9cc59c; }
+      .text { font-family: 'Inter', 'Segoe UI', sans-serif; fill: #1f2f1f; }
+      .caption { font-size: 18px; font-weight: 700; }
+      .label { font-size: 14px; }
+    </style>
+  </defs>
+  <rect class="bg" x="24" y="24" width="620" height="420" rx="14" />
+  <text class="text caption" x="38" y="58">BattleMap tactical view</text>
+  <g transform="translate(54 90)">
+    <rect class="grid" x="0" y="0" width="420" height="280" rx="12" />
+    <rect class="token" x="40" y="60" width="48" height="48" rx="10" />
+    <text class="text label" x="46" y="92">PC</text>
+    <rect class="enemy" x="180" y="120" width="48" height="48" rx="10" />
+    <text class="text label" x="188" y="152">Enemy</text>
+    <rect class="token" x="260" y="200" width="48" height="48" rx="10" />
+    <text class="text label" x="268" y="232">Ally</text>
+    <text class="text label" x="8" y="308">Grid tiles rendered by BattleMapTile</text>
+  </g>
+  <rect class="panel" x="520" y="90" width="330" height="70" rx="12" />
+  <text class="text caption" x="536" y="118">InitiativeTracker</text>
+  <text class="text label" x="536" y="142">Highlights active combatant</text>
+  <rect class="panel" x="520" y="180" width="330" height="120" rx="12" />
+  <text class="text caption" x="536" y="208">AbilityPalette</text>
+  <text class="text label" x="536" y="234">Shows costs (Action/Bonus/etc.)</text>
+  <text class="text label" x="536" y="258">Disables when resources spent</text>
+  <rect class="panel" x="520" y="320" width="330" height="110" rx="12" />
+  <text class="text caption" x="536" y="350">CombatLog</text>
+  <text class="text label" x="536" y="376">Narrates actions resolved by hooks</text>
+  <rect class="panel" x="40" y="360" width="420" height="90" rx="12" />
+  <text class="text caption" x="52" y="390">Supporting hooks</text>
+  <text class="text label" x="52" y="414">• useTurnManager controls rounds</text>
+  <text class="text label" x="52" y="438">• useAbilitySystem validates targeting</text>
+</svg>

--- a/docs/images/character-creator-steps.svg
+++ b/docs/images/character-creator-steps.svg
@@ -1,0 +1,54 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="900" height="540" viewBox="0 0 900 540" role="img" aria-label="Character creator stepper and preview">
+  <defs>
+    <style>
+      .bg { fill: #f3f6ff; stroke: #9fb7f5; stroke-width: 4; }
+      .step { fill: #dbe3ff; stroke: #6c84d9; }
+      .active { fill: #6c84d9; stroke: #32447d; }
+      .text { font-family: 'Inter', 'Segoe UI', sans-serif; fill: #1f2a44; }
+      .caption { font-size: 18px; font-weight: 700; }
+      .label { font-size: 14px; }
+      .panel { fill: #ffffff; stroke: #9fb7f5; }
+    </style>
+  </defs>
+  <rect class="bg" x="24" y="24" width="852" height="492" rx="16" />
+  <text class="text caption" x="40" y="58">CharacterCreator multi-step flow</text>
+  <g transform="translate(60 90)">
+    <rect class="step active" x="0" y="0" width="120" height="60" rx="10" />
+    <text class="text caption" x="16" y="36" fill="#fff">Race</text>
+    <rect class="step" x="140" y="0" width="120" height="60" rx="10" />
+    <text class="text caption" x="156" y="36">Class</text>
+    <rect class="step" x="280" y="0" width="160" height="60" rx="10" />
+    <text class="text caption" x="296" y="36">Ability Scores</text>
+    <rect class="step" x="460" y="0" width="130" height="60" rx="10" />
+    <text class="text caption" x="476" y="36">Skills</text>
+    <rect class="step" x="610" y="0" width="140" height="60" rx="10" />
+    <text class="text caption" x="626" y="36">Name &amp; Review</text>
+    <text class="text label" x="0" y="88">Reducer-driven steps with framer-motion transitions</text>
+  </g>
+  <g transform="translate(60 150)">
+    <rect class="panel" x="0" y="0" width="520" height="220" rx="14" />
+    <text class="text caption" x="16" y="32">Current step panel</text>
+    <text class="text label" x="16" y="60">• Renders step-specific component</text>
+    <text class="text label" x="16" y="86">• Dispatches actions to reducer</text>
+    <text class="text label" x="16" y="112">• Validates requirements before advancing</text>
+    <text class="text label" x="16" y="138">• Shows contextual helper copy</text>
+  </g>
+  <g transform="translate(600 150)">
+    <rect class="panel" x="0" y="0" width="240" height="220" rx="14" />
+    <text class="text caption" x="14" y="32">Preview &amp; CTA</text>
+    <text class="text label" x="14" y="62">• Live character preview</text>
+    <text class="text label" x="14" y="88">• Back button uses GO_BACK logic</text>
+    <text class="text label" x="14" y="114">• Final submission calls assemble</text>
+    <text class="text label" x="14" y="140">• Dummy mode swap supported</text>
+  </g>
+  <g transform="translate(60 390)">
+    <rect class="panel" x="0" y="0" width="320" height="90" rx="12" />
+    <text class="text caption" x="12" y="32">State sources</text>
+    <text class="text label" x="12" y="58">• characterCreatorState reducer</text>
+    <text class="text label" x="12" y="82">• useCharacterAssembly hook</text>
+    <rect class="panel" x="340" y="0" width="300" height="90" rx="12" />
+    <text class="text caption" x="352" y="32">Accessibility</text>
+    <text class="text label" x="352" y="58">• Button labels for navigation</text>
+    <text class="text label" x="352" y="82">• Keyboard focus maintained</text>
+  </g>
+</svg>

--- a/docs/images/map-pane-overlay.svg
+++ b/docs/images/map-pane-overlay.svg
@@ -1,0 +1,42 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="900" height="540" viewBox="0 0 900 540" role="img" aria-label="MapPane overlay with legend and tiles">
+  <defs>
+    <style>
+      .bg { fill: #f5e6c4; stroke: #cfa968; stroke-width: 4; }
+      .tile { fill: #7cbf7c; stroke: #3f7f3f; }
+      .tile-undiscovered { fill: #d6d6d6; stroke: #777; }
+      .tile-player { fill: #88c9f9; stroke: #1b6ea8; stroke-width: 3; }
+      .text { font-family: 'Inter', 'Segoe UI', sans-serif; fill: #2d1f0f; }
+      .caption { font-size: 18px; font-weight: 600; }
+      .label { font-size: 14px; }
+      .legend { fill: #fff8e6; stroke: #cfa968; }
+    </style>
+  </defs>
+  <rect class="bg" x="30" y="30" width="620" height="420" rx="18" />
+  <text class="text caption" x="40" y="60">MapPane overlay (keyboard-friendly modal)</text>
+  <g transform="translate(60 90)">
+    <rect class="tile" x="0" y="0" width="70" height="70" rx="8" />
+    <text class="text label" x="10" y="40">Forest biome</text>
+    <rect class="tile-undiscovered" x="90" y="0" width="70" height="70" rx="8" />
+    <text class="text label" x="100" y="40">Fog of war</text>
+    <rect class="tile-player" x="180" y="0" width="70" height="70" rx="8" />
+    <text class="text label" x="190" y="40">Player</text>
+    <rect class="tile" x="270" y="0" width="70" height="70" rx="8" />
+    <text class="text label" x="278" y="40">City</text>
+  </g>
+  <g transform="translate(60 180)">
+    <rect class="tile" x="0" y="0" width="420" height="220" rx="14" opacity="0.35" />
+    <text class="text caption" x="12" y="28">Grid tiles accept click or Enter/Space</text>
+    <text class="text label" x="12" y="56">Arrow keys move focus • Tab loops close button &amp; focused tile</text>
+    <text class="text label" x="12" y="80">Selected tile announced via aria-label</text>
+  </g>
+  <rect class="legend" x="680" y="60" width="190" height="210" rx="10" />
+  <text class="text caption" x="694" y="90">Legend</text>
+  <text class="text label" x="694" y="120">Green: Discovered biome</text>
+  <text class="text label" x="694" y="146">Grey: Undiscovered</text>
+  <text class="text label" x="694" y="172">Blue pin: Player</text>
+  <text class="text label" x="694" y="198">Icons from BIOMES/LOCATIONS</text>
+  <rect class="legend" x="680" y="290" width="190" height="140" rx="10" />
+  <text class="text caption" x="694" y="318">Close/Instructions</text>
+  <text class="text label" x="694" y="344">• Close Map button focused first</text>
+  <text class="text label" x="694" y="368">• Esc closes overlay</text>
+</svg>

--- a/docs/images/submap-pane.svg
+++ b/docs/images/submap-pane.svg
@@ -1,0 +1,42 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="900" height="540" viewBox="0 0 900 540" role="img" aria-label="Submap pane with tooltip, legend, and compass">
+  <defs>
+    <style>
+      .bg { fill: #eaf0ff; stroke: #8ea8d8; stroke-width: 4; }
+      .tile { fill: #b7d3ff; stroke: #5e7fb3; }
+      .path { fill: #d9b382; stroke: #9c774a; }
+      .feature { fill: #8fd1c7; stroke: #3c8f7d; }
+      .text { font-family: 'Inter', 'Segoe UI', sans-serif; fill: #233047; }
+      .caption { font-size: 18px; font-weight: 700; }
+      .label { font-size: 14px; }
+      .panel { fill: #ffffff; stroke: #a6b8db; }
+    </style>
+  </defs>
+  <rect class="bg" x="24" y="24" width="630" height="420" rx="14" />
+  <text class="text caption" x="38" y="56">SubmapPane — zoomed-in grid view</text>
+  <g transform="translate(54 86)">
+    <rect class="tile" x="0" y="0" width="340" height="260" rx="12" opacity="0.4" />
+    <rect class="path" x="20" y="60" width="300" height="40" rx="10" />
+    <rect class="feature" x="120" y="150" width="80" height="80" rx="14" />
+    <text class="text label" x="26" y="40">Procedural paths &amp; features</text>
+    <text class="text label" x="26" y="220">Seeded ponds/thickets avoid paths</text>
+    <rect class="panel" x="360" y="0" width="180" height="90" rx="10" />
+    <text class="text caption" x="372" y="28">Tile tooltip</text>
+    <text class="text label" x="372" y="54">• Inspect mode reveals details</text>
+    <text class="text label" x="372" y="78">• Tooltip text from hints/log</text>
+    <rect class="panel" x="0" y="280" width="220" height="90" rx="10" />
+    <text class="text caption" x="12" y="308">CompassPane inline</text>
+    <text class="text label" x="12" y="334">Cardinal controls for movement</text>
+    <text class="text label" x="12" y="358">Disabled state supported</text>
+    <rect class="panel" x="240" y="280" width="300" height="90" rx="10" />
+    <text class="text caption" x="252" y="308">Legend modal</text>
+    <text class="text label" x="252" y="334">Summarizes icons &amp; colors</text>
+    <text class="text label" x="252" y="358">Accessible via button</text>
+  </g>
+  <rect class="panel" x="680" y="60" width="190" height="360" rx="12" />
+  <text class="text caption" x="694" y="92">Data sources</text>
+  <text class="text label" x="694" y="122">• useSubmapProceduralData</text>
+  <text class="text label" x="694" y="148">• submapVisualsConfig</text>
+  <text class="text label" x="694" y="174">• Tooltip + Legend data</text>
+  <text class="text label" x="694" y="204">Cellular automata for caves</text>
+  <text class="text label" x="694" y="232">Paths skipped when CA grid</text>
+</svg>

--- a/docs/images/village-scene.svg
+++ b/docs/images/village-scene.svg
@@ -1,0 +1,36 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="900" height="540" viewBox="0 0 900 540" role="img" aria-label="Village scene layout with buildings and status bar">
+  <defs>
+    <style>
+      .bg { fill: #f8f1e6; stroke: #d8bfa3; stroke-width: 4; }
+      .ground { fill: #e7d9c3; stroke: #c3a47c; }
+      .building { fill: #d6b48a; stroke: #8b6339; }
+      .text { font-family: 'Inter', 'Segoe UI', sans-serif; fill: #2f2415; }
+      .caption { font-size: 18px; font-weight: 700; }
+      .label { font-size: 14px; }
+      .panel { fill: #ffffff; stroke: #d8bfa3; }
+    </style>
+  </defs>
+  <rect class="bg" x="24" y="24" width="852" height="492" rx="18" />
+  <text class="text caption" x="40" y="58">VillageScene canvas-style view</text>
+  <g transform="translate(60 90)">
+    <rect class="ground" x="0" y="0" width="520" height="320" rx="14" />
+    <rect class="building" x="40" y="40" width="140" height="90" rx="12" />
+    <text class="text label" x="56" y="92">Inn</text>
+    <rect class="building" x="220" y="70" width="140" height="90" rx="12" />
+    <text class="text label" x="236" y="122">Shop</text>
+    <rect class="building" x="140" y="190" width="200" height="90" rx="12" />
+    <text class="text label" x="156" y="242">Workshop</text>
+    <text class="text label" x="20" y="280">Procedural buildings plotted from village data</text>
+  </g>
+  <rect class="panel" x="600" y="90" width="240" height="120" rx="12" />
+  <text class="text caption" x="614" y="120">Scene status</text>
+  <text class="text label" x="614" y="148">• Canvas renders map &amp; NPCs</text>
+  <text class="text label" x="614" y="172">• ImagePane disabled (API quota)</text>
+  <rect class="panel" x="600" y="230" width="240" height="120" rx="12" />
+  <text class="text caption" x="614" y="260">Interaction hooks</text>
+  <text class="text label" x="614" y="288">• Map click -> actions</text>
+  <text class="text label" x="614" y="312">• Quick travel entry point</text>
+  <rect class="panel" x="60" y="430" width="520" height="62" rx="12" />
+  <text class="text caption" x="74" y="466">UI overlay</text>
+  <text class="text label" x="190" y="466">Action buttons / tooltips</text>
+</svg>

--- a/src/components/BattleMap/BattleMap.README.md
+++ b/src/components/BattleMap/BattleMap.README.md
@@ -9,6 +9,10 @@ The Battle Map feature provides a tactical, grid-based view for combat encounter
 
 The combat system uses a D&D 5th Edition-style action economy, where characters have an **Action**, **Bonus Action**, **Reaction**, and a set amount of **Movement** each turn.
 
+## Visual Reference
+
+![Battle map grid with tokens and supporting UI](../../../docs/images/battle-map.svg)
+
 ## Core Components
 
 The feature is built from several key components and services:

--- a/src/components/CharacterCreator/CharacterCreator.README.md
+++ b/src/components/CharacterCreator/CharacterCreator.README.md
@@ -8,6 +8,10 @@ It now manages its state using a `useReducer` hook with logic extracted into **`
 
 The final `PlayerCharacter` object includes all pre-calculated derived stats (like `darkvisionRange`, final `speed`, `maxHp`, `armorClass`) and fully aggregated spell lists, serving as the single source of truth for these values.
 
+## Visual Reference
+
+![Character creator stepper, current panel, and preview](../../../docs/images/character-creator-steps.svg)
+
 ## Structure
 
 The character creation process is divided into several steps, managed by the `CreationStep` enum (now in `characterCreatorState.ts`). The UI for each distinct selection part of a step is handled by dedicated sub-components.

--- a/src/components/MapPane.README.md
+++ b/src/components/MapPane.README.md
@@ -4,6 +4,10 @@
 
 The `MapPane.tsx` component is responsible for rendering the game's world map as a visual overlay. It allows players to see discovered areas, their current position, and the biomes of different regions. Players can interact with the map by clicking on discovered tiles to potentially travel to linked locations. It now features enhanced keyboard navigation and an icon glossary.
 
+## Visual Reference
+
+![MapPane overlay with legend and keyboard guidance](../../docs/images/map-pane-overlay.svg)
+
 ## Props
 
 *   **`mapData: MapData`**:

--- a/src/components/SubmapPane.README.md
+++ b/src/components/SubmapPane.README.md
@@ -15,6 +15,10 @@ Key features include:
 *   **Tile Inspection**: An "Inspect Tile" mode allows players to get detailed, AI-generated descriptions of adjacent tiles.
 *   **Compass Integration**: The `CompassPane` is now rendered directly within this component, providing a unified local navigation experience.
 
+## Visual Reference
+
+![Submap grid with tooltips, compass, and legend callouts](../../docs/images/submap-pane.svg)
+
 ## Configuration
 
 The visual appearance of each biome (base colors, path styles, scatter features, etc.) is not hardcoded within this component. It is defined in a dedicated configuration file: **`src/config/submapVisualsConfig.ts`**. This separation of concerns allows for easier tuning of the submap's aesthetic without modifying the component's rendering logic.

--- a/src/components/VillageScene.README.md
+++ b/src/components/VillageScene.README.md
@@ -1,0 +1,21 @@
+# VillageScene Component
+
+## Purpose
+
+`VillageScene.tsx` renders the in-village experience using a canvas-style layout. It plots procedurally determined buildings (inn, shop, workshop, etc.), paths, and interaction hotspots based on generated village data. The scene is reached through the village game phase and is designed to feel distinct per settlement seed.
+
+## Visual Reference
+
+![Canvas-style village layout with building callouts](../../docs/images/village-scene.svg)
+
+## Core Responsibilities
+
+*   **Canvas Rendering**: Draws terrain, roads, and building footprints so each village feels spatially unique.
+*   **Interaction Surfaces**: Building hitboxes drive actions such as opening merchant flows or triggering quick travel back to the overworld.
+*   **Phase Awareness**: Operates when the game is in `VILLAGE_VIEW`, coordinating with map/village state and world seed data.
+*   **Performance Considerations**: Keeps visuals lightweight to match the procedural map cadence.
+
+## Current Status
+
+*   **Scene Visuals Paused**: The related `ImagePane.tsx`/image-generation path is intentionally disabled to avoid exceeding API quotas. The canvas layout remains the primary presentation.
+*   **Future Enhancements**: Expand building variety, layer NPC sprites, and surface more tooltips for available services.

--- a/src/hooks/useSubmapProceduralData.README.md
+++ b/src/hooks/useSubmapProceduralData.README.md
@@ -3,15 +3,7 @@
 
 ## Purpose
 
-The `useSubmapProceduralData` custom React hook is designed to encapsulate and manage the procedural generation of data required by the `SubmapPane.tsx` component. This includes:
-
-1.  **Deterministic Hashing (`simpleHash`)**: Provides a hash function that generates consistent pseudo-random numbers based on submap coordinates, the parent world map tile's coordinates, and the biome ID. This is crucial for ensuring that submap features are generated consistently for any given tile.
-2.  **Seeded Feature Placement (`activeSeededFeatures`)**: Calculates the positions and actual sizes of major "seeded" features (like ponds, thickets, villages) within the submap grid based on configurations defined in `SubmapPane.tsx`.
-3.  **Path Generation (`pathDetails`)**: Determines the coordinates for main paths running through the submap and the tiles adjacent to these paths.
-    *   **Path Stability**: The main path's layout (starting point and general course) is static for all submaps, including the starting one. It is determined solely by world coordinates and biome.
-    *   **Starting Path Guarantee**: For the player's initial starting submap (the one corresponding to `STARTING_LOCATION_ID`), this hook explicitly ensures that the submap's **fixed center coordinates** (e.g., `cols/2`, `rows/2`) are included in the `mainPathCoords` set. Since the player character also begins at these center coordinates, this guarantees they start on a path tile, and the path remains static. This fixes previous issues where the path might dynamically adjust to the player's current position on the starting submap.
-
-By extracting this logic, `SubmapPane.tsx` can focus more on the visual rendering of the submap, while the data generation aspect is handled by this hook.
+The `useSubmapProceduralData` custom React hook encapsulates the procedural generation concerns that power `SubmapPane.tsx`. It produces deterministic hashes, seeded feature placement, optional cellular automata grids for cave/dungeon biomes, and path layouts that avoid feature collisions while keeping the starting submap stable.
 
 ## Interface
 
@@ -21,13 +13,14 @@ interface UseSubmapProceduralDataProps {
   currentWorldBiomeId: string;
   parentWorldMapCoords: { x: number; y: number };
   seededFeaturesConfig?: SeededFeatureConfig[]; // From SubmapPane's biomeVisualsConfig
-  // playerSubmapCoordsForPath prop has been removed
+  worldSeed: number;
 }
 
 interface UseSubmapProceduralDataOutput {
   simpleHash: (submapX: number, submapY: number, seedSuffix: string) => number;
   activeSeededFeatures: Array<{ x: number; y: number; config: SeededFeatureConfig; actualSize: number }>;
   pathDetails: PathDetails; // Contains mainPathCoords and pathAdjacencyCoords Sets
+  caGrid?: CaTileType[][];
 }
 
 function useSubmapProceduralData(props: UseSubmapProceduralDataProps): UseSubmapProceduralDataOutput;
@@ -37,6 +30,7 @@ function useSubmapProceduralData(props: UseSubmapProceduralDataProps): UseSubmap
 *   **`currentWorldBiomeId`**: The ID of the biome for the parent world map tile.
 *   **`parentWorldMapCoords`**: The (x,y) coordinates of the parent world map tile.
 *   **`seededFeaturesConfig`**: The configuration array for seeded features, typically passed from `SubmapPane`'s `biomeVisualsConfig`.
+*   **`worldSeed`**: The world seed used to keep submap and CA generation deterministic across sessions.
 
 
 ## Return Value
@@ -44,7 +38,7 @@ function useSubmapProceduralData(props: UseSubmapProceduralDataProps): UseSubmap
 The hook returns an object containing:
 
 *   **`simpleHash: (submapX, submapY, seedSuffix) => number`**:
-    *   A memoized hash function. Takes submap tile coordinates and a string suffix to generate a pseudo-random number. Crucially, it incorporates `parentWorldMapCoords` and `currentWorldBiomeId` into its internal seed string, ensuring unique procedural generation for each distinct world map tile.
+    *   A memoized hash function. Takes submap tile coordinates and a string suffix to generate a pseudo-random number. Crucially, it incorporates `worldSeed`, `parentWorldMapCoords`, and `currentWorldBiomeId` into its internal seed string, ensuring unique procedural generation for each distinct world map tile.
 
 *   **`activeSeededFeatures: Array<{...}>`**:
     *   A memoized array. Each object in the array represents an instance of a seeded feature to be placed on the submap, including its seed coordinates (`x`, `y`), its specific `config` (from `seededFeaturesConfig`), and its `actualSize` (randomly determined within `config.sizeRange`).
@@ -54,12 +48,17 @@ The hook returns an object containing:
     *   `mainPathCoords`: A `Set` of strings (e.g., "x,y") representing tiles that are part of a main path.
     *   `pathAdjacencyCoords`: A `Set` of strings representing tiles adjacent to the main path.
     *   The path generation logic considers the biome (e.g., less chance of paths in swamps). If it's the initial starting submap, it explicitly adds the **fixed center coordinates** of that submap to `mainPathCoords`.
+    *   When a CA grid is produced for caves/dungeons, standard paths are skipped to let the generated cavern map define traversable space.
+*   **`caGrid?: CaTileType[][]`**:
+    *   Optional 2D grid returned when the biome uses cellular automata (cave/dungeon). Generated with a deterministic seed derived from `worldSeed` and the parent coordinates.
+    *   Enables `SubmapPane` to render CA tiles instead of standard path/feature tiles when present.
 
 ## Core Logic
 
-*   **`simpleHash`**: Implements a basic string hashing algorithm.
-*   **`activeSeededFeatures`**: Iterates through `seededFeaturesConfig`. For each feature type, it uses `simpleHash` to determine how many instances to place and their random seed coordinates and sizes within the submap.
-*   **`pathDetails`**: Uses `simpleHash` to decide if a path exists, its orientation (vertical/horizontal), its starting position, and its "wobble" as it traverses the submap. It then calculates adjacent tiles. If it's the initial starting submap, it explicitly adds the fixed center coordinates of that submap to `mainPathCoords`.
+*   **`simpleHash`**: Implements a basic string hashing algorithm anchored on `worldSeed`, biome, and parent coordinates.
+*   **`caGrid`**: When the biome is `cave` or `dungeon`, generates a deterministic cellular automata grid instead of standard paths/features.
+*   **`activeSeededFeatures`**: Iterates through `seededFeaturesConfig`. For each feature type, it uses `simpleHash` to determine how many instances to place and their random seed coordinates and sizes within the submap. Features that collide with the main path are skipped.
+*   **`pathDetails`**: Uses `simpleHash` to decide if a path exists, its orientation (vertical/horizontal), its starting position, and its "wobble" as it traverses the submap. It then calculates adjacent tiles. If it's the initial starting submap, it explicitly adds the fixed center coordinates of that submap to `mainPathCoords`. When `caGrid` exists, path generation is bypassed.
 
 ## Usage
 
@@ -75,11 +74,12 @@ const SubmapPane: React.FC<SubmapPaneProps> = ({
   // ... other props ...
 }) => {
   // ... get visualsConfig ...
-  const { simpleHash, activeSeededFeatures, pathDetails } = useSubmapProceduralData({
+  const { simpleHash, activeSeededFeatures, pathDetails, caGrid } = useSubmapProceduralData({
     submapDimensions,
     currentWorldBiomeId,
     parentWorldMapCoords,
     seededFeaturesConfig: visualsConfig.seededFeatures,
+    worldSeed,
   });
 
   // Now use simpleHash, activeSeededFeatures, pathDetails for rendering decisions
@@ -98,4 +98,5 @@ const SubmapPane: React.FC<SubmapPaneProps> = ({
 ## Dependencies
 *   `react`: For `useMemo`, `useCallback`.
 *   `../constants`: For `LOCATIONS`, `STARTING_LOCATION_ID`, `BIOMES`.
-*   Types defined within the hook file (`SeededFeatureConfig`, `PathDetails`) or imported from `../types`.
+*   `../services/cellularAutomataService`: For CA grids used in cave/dungeon biomes.
+*   Types defined within the hook file (`SeededFeatureConfig`, `PathDetails`, `CaTileType`) or imported from `../types`.


### PR DESCRIPTION
## Summary
- add illustrative SVG visuals to MapPane, SubmapPane, CharacterCreator, BattleMap, and VillageScene READMEs
- clarify paused scene visuals status and expand feat system implementation notes in project docs
- refresh hook READMEs and documentation index entries to reflect current behavior

## Testing
- not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924e6a948c4832f821cb8b8b54d2793)