### PR TITLE
[SCRIBE] Add comprehensive 5e scaling mechanics documentation

### DIFF
--- a/.jules/worklogs/worklog_scribe.md
+++ b/.jules/worklogs/worklog_scribe.md
@@ -1,5 +1,15 @@
 # Scribe's Journal
 
+## 2025-12-29 - ScalingEngine Documentation
+**Task:** Document 5e spell scaling mechanics in `ScalingEngine.ts`
+**Changes:** Added comprehensive JSDoc explaining:
+- Slot-level scaling formula with Fireball example
+- Character-level cantrip scaling tiers (5, 11, 17)
+- Multiclass interaction notes
+- PHB reference
+**Note:** Original Jules run blocked by package-lock.json issue; salvaged by Gemini.
+
 ## 2024-05-23 - Undocumented Command Classes
 **Learning:** Complex Command classes (like `ReactiveEffectCommand`) often lack file-level and class-level JSDoc, making it hard to understand their role in the Command/Event architecture, specifically the distinction between immediate execution and listener registration.
 **Action:** When adding or reviewing Command classes, always explain *when* they execute (immediate vs delayed) and *what* external systems they interact with (e.g. Event Emitters, SustainSystem) in the class-level TSDoc.
+

--- a/src/systems/spells/mechanics/ScalingEngine.ts
+++ b/src/systems/spells/mechanics/ScalingEngine.ts
@@ -1,11 +1,48 @@
 import type { ScalingFormula } from '@/types/spells'
 
 /**
- * Handles spell upscaling calculations
+ * [SCRIBE] Handles spell upscaling calculations for D&D 5e
  *
- * D&D 5e spells scale in two ways:
- * 1. Slot level: Casting at higher spell slot (e.g., Fireball at 4th level)
- * 2. Character level: Cantrips scale with character level
+ * ## D&D 5e Spell Scaling Mechanics
+ *
+ * Spells in 5e scale damage/effects in two distinct ways:
+ *
+ * ### 1. Slot-Level Scaling (Leveled Spells)
+ * When casting a spell using a higher-level spell slot than required:
+ * - Base damage is calculated at the spell's minimum level
+ * - Bonus damage is added per slot level above minimum
+ *
+ * **Example: Fireball (3rd-level)**
+ * - Base: 8d6 fire damage
+ * - At 4th level: 8d6 + 1d6 = 9d6
+ * - At 5th level: 8d6 + 2d6 = 10d6
+ * - Formula: `baseDice + (bonusPerLevel × (castLevel - baseLevel))`
+ *
+ * ### 2. Character-Level Scaling (Cantrips)
+ * Cantrips scale with the caster's total character level, NOT class level.
+ * Multiclass characters use their total level for cantrip scaling.
+ *
+ * **Standard Cantrip Scaling Tiers:**
+ * | Caster Level | Dice Multiplier |
+ * |--------------|-----------------|
+ * | 1-4          | 1x (base)       |
+ * | 5-10         | 2x              |
+ * | 11-16        | 3x              |
+ * | 17+          | 4x              |
+ *
+ * **Example: Fire Bolt**
+ * - Level 1: 1d10
+ * - Level 5: 2d10
+ * - Level 11: 3d10
+ * - Level 17: 4d10
+ *
+ * ### Implementation Notes
+ *
+ * This engine supports both scaling types and prefers explicit tier definitions
+ * (via `scalingTiers` in spell data) over calculated values for accuracy.
+ *
+ * @see {@link ScalingFormula} for the spell data structure
+ * @see PHB p.201 for official scaling rules
  */
 export class ScalingEngine {
   /**


### PR DESCRIPTION
## Summary
Salvaged from a failed Jules run that got blocked by package-lock.json issues.

## Changes
Added detailed JSDoc documentation to \ScalingEngine.ts\ explaining:

### Slot-Level Scaling (Leveled Spells)
- How bonus damage is added per slot level above minimum
- Fireball example: 8d6  9d6  10d6
- Formula: \aseDice + (bonusPerLevel × (castLevel - baseLevel))\

### Character-Level Scaling (Cantrips)
- Standard scaling tiers at levels 5, 11, 17
- Multiclass interaction notes (uses total character level)
- Fire Bolt example

### References
- PHB p.201 for official rules
- \@see\ links to related types

## Worklog
Updated \.jules/worklogs/worklog_scribe.md\ with entry about this documentation task.

---
*Salvaged by Gemini from failed Scribe Jules run*