### PR TITLE
[codex] Prepare Spell Phase 1 Package 3 handoff

### DIFF
--- a/conductor/symphony/docs/decision-reports/SPELL_PHASE_1_ASSUMED_APPROVAL_DECISIONS.md
+++ b/conductor/symphony/docs/decision-reports/SPELL_PHASE_1_ASSUMED_APPROVAL_DECISIONS.md
@@ -1731,10 +1731,96 @@ Copy this block for each decision.
   tests, CodeQL, and poison-file checks also passed.
 - Next expected proof: Merge PR #938, then continue to Package 3 packaging.
 
+### Decision 44: Package Character Creator And Spellbook Visibility As The Next Jules Slice
+
+- Date/time: 2026-05-22
+- Phase: `package_3_pre_dispatch`
+- Active slice: Package 3 spellbook and character creator visibility
+- Decision point: Whether Codex should repair the character creator/spellbook
+  UI locally, send a broad "finish spell UI" request to Jules, or create a
+  bounded Package 3 task packet for dashboard-first Jules offload.
+- Options considered:
+  - Implement the UI/assembly repairs locally in the foreman session.
+  - Send Jules a broad prompt covering character creator, spellbook, combat
+    simulator spell casting, AI arbitration, and level 2-3 fixtures together.
+  - Create a bounded Package 3 packet focused on character creator spell
+    selection and character sheet spellbook visibility, leaving combat and AI
+    arbitration to Packages 4 and 5.
+- Decision made by agent: Create the bounded Package 3 task packet for Jules
+  and keep Codex in the foreman role.
+- Model routing: Strong local foreman reasoning, because this defines the next
+  write-producing slice and prevents scope bleed into combat/runtime or
+  arbitration policy.
+- Rationale/evidence: Package 2 is merged and the Phase 1 plan names Package 3
+  as the next sequential slice. Current source inspection shows repeated
+  class-specific spell selectors, a live Spellbook tab/overlay surface, and a
+  possible known/prepared semantics ambiguity in character assembly. Those are
+  clear enough for a bounded Jules implementation task, while combat simulator
+  spell behavior and AI arbitration remain separate later packages.
+- Mutation performed or skipped: Created
+  `docs/tasks/spells/PACKAGE_3_SPELLBOOK_CREATOR_VISIBILITY_JULES_TASK.md`,
+  `docs/tasks/spells/PACKAGE_3_SPELLBOOK_CREATOR_VISIBILITY_JULES_PROMPT.md`,
+  `docs/tasks/spells/PACKAGE_3_DISPATCH_READINESS_CHECKLIST.md`,
+  `docs/tasks/spells/PACKAGE_3_SYMPHONY_TASK_DRAFT_PAYLOAD.json`,
+  `docs/tasks/spells/PACKAGE_3_ATLAS_GATE_CHECKPOINT_RECEIPT.md`, and
+  `docs/tasks/spells/PACKAGE_3_VISUAL_PROOF_RECEIPT.md`. Updated the living
+  tracker to make Package 3 active and record adjacent gaps.
+- Scope guardrails: Package 3 excludes combat simulator casting behavior, broad
+  spell schema/runtime architecture, AI arbitration policy, and premade roster
+  semantics except tiny test fixtures if strictly necessary.
+- Result: Package 3 is packaged for dashboard draft creation. It is not yet
+  dispatched to Jules.
+- Next expected proof: Use the visible Symphony dashboard to create the Package
+  3 task draft from the payload, then record the draft id, any blocker, and the
+  handoff path in the Package 3 readiness checklist.
+
+### Decision 45: Do Not Push Diverged Local Master For The Package 3 Base
+
+- Date/time: 2026-05-22
+- Phase: `package_3_dashboard_git_gate`
+- Active slice: Package 3 spellbook and character creator visibility
+- Decision point: The visible Symphony dashboard blocked Package 3 draft work
+  at the Git sync gate. It showed local `master` with two local-only
+  racial-mechanics commits and three remote-only Spell Phase 1 commits, while
+  the active Package 3 docs were on `codex/spell-phase1-package3-planning`.
+- Options considered:
+  - Follow the dashboard-generated human command suggestion to push/pull
+    `master`.
+  - Reset or move local `master` to GitHub, discarding or burying the local-only
+    racial-mechanics commits.
+  - Record dashboard dispositions, keep the unrelated local `master` commits
+    local, and commit the Package 3 task packet on the package branch.
+- Decision made by agent: Record the dashboard dispositions visibly, keep the
+  unrelated local `master` commits local, and commit Package 3 docs on the
+  package branch.
+- Model routing: Strong local foreman reasoning, because this decision protects
+  unrelated local work and prevents a workflow tool suggestion from becoming a
+  destructive Git action.
+- Rationale/evidence: The dashboard Git Safety board identified local-only
+  commits `1cc84428` and `42af4f59`, both carrying broad racial-mechanics work
+  unrelated to Package 3. The same board identified the Package 3 docs as
+  untracked source artifacts needed for the Jules base. Pushing `master` would
+  publish unrelated work; resetting `master` would endanger it.
+- Mutation performed or skipped: Used the visible dashboard Git Safety board to
+  record `Local-only commits = Keep local` and
+  `Untracked artifacts = Commit for Jules base`. Skipped pushing or pulling
+  local `master`. Prepared the package branch commit instead.
+- Scope guardrails: Do not delete, reset, squash, or publish the unrelated
+  racial-mechanics local commits from this spell flow. Do not create a Jules
+  handoff until Package 3 docs are visible from a safe GitHub base.
+- Result: Dashboard-first flow exposed a valid Git ownership blocker and the
+  agent selected the non-destructive branch path.
+- Next expected proof: Commit and publish the Package 3 planning branch, open
+  the PR, merge it if checks pass, then re-enter the dashboard from a base that
+  can see the Package 3 docs without touching unrelated local `master` work.
+
 ## Open Decisions For The Next Slice
 
-1. Merge PR #938 after the clean check set.
+1. Create the Package 3 Symphony dashboard draft visibly from
+   `PACKAGE_3_SYMPHONY_TASK_DRAFT_PAYLOAD.json`.
 2. Package and dispatch Package 3 for Jules: character creator spell selection
    and character sheet spellbook visibility.
-3. Keep Stitch MCP authentication as an adjacent tooling gap until an API key or
-   OAuth path is installed and Codex is restarted.
+3. Improve Symphony Git sync guidance so a planning branch can be published
+   without suggesting that unrelated local `master` commits should be pushed.
+4. Confirm the restarted Stitch MCP proxy path before claiming any
+   Stitch-generated dashboard redesign work.

--- a/docs/tasks/spells/PACKAGE_2_DISPATCH_READINESS_CHECKLIST.md
+++ b/docs/tasks/spells/PACKAGE_2_DISPATCH_READINESS_CHECKLIST.md
@@ -2,6 +2,11 @@
 
 Status: dispatched to Jules; waiting on Jules queue/plan/PR state.
 
+Historical closeout note: Package 2 has since completed the dispatch, Jules
+session, PR, review, merge, and closeout path. This checklist is retained as
+evidence of the handoff guard that was used; the current active package state
+lives in `docs/tasks/spells/SPELL_PHASE_1_TASK_TRACKER.md`.
+
 This checklist is the handoff guard between the prepared Package 2 artifacts and
 the first write-producing Jules implementation slice. It exists so a future
 foreman can tell exactly what is ready, what is blocked, and which action would

--- a/docs/tasks/spells/PACKAGE_2_PREMADE_PARTY_GEAR_JULES_PROMPT.md
+++ b/docs/tasks/spells/PACKAGE_2_PREMADE_PARTY_GEAR_JULES_PROMPT.md
@@ -2,6 +2,11 @@
 
 Status: prompt-ready, not dispatched.
 
+Historical closeout note: Package 2 has since been dispatched to Jules and
+merged through PR #935. This prompt is retained as evidence of what Jules was
+asked to do; the current active package state lives in
+`docs/tasks/spells/SPELL_PHASE_1_TASK_TRACKER.md`.
+
 Do not paste this into Jules until
 `docs/tasks/spells/SPELL_PHASE_1_JULES_ENVIRONMENT_SNAPSHOT_RECEIPT.md` has a
 real `passed` or approved `waived` result and the matching decision-report entry

--- a/docs/tasks/spells/PACKAGE_2_PREMADE_PARTY_GEAR_JULES_TASK.md
+++ b/docs/tasks/spells/PACKAGE_2_PREMADE_PARTY_GEAR_JULES_TASK.md
@@ -3,6 +3,12 @@
 Status: local Symphony draft created; setup branch pushed; fresh Symphony
 readiness preflight required before Jules dispatch.
 
+Historical closeout note: Package 2 has since been dispatched to Jules,
+reviewed, repaired through the dashboard-first workflow where needed, and merged
+through PR #935. This file is retained as the original implementation contract;
+the current active package state lives in
+`docs/tasks/spells/SPELL_PHASE_1_TASK_TRACKER.md`.
+
 This is the first implementation slice for Spell Phase 1 after the Symphony
 post-ARA-6 cleanup and Package 1 baseline. It intentionally focuses on premade
 level-1 characters and combat-ready gear before broader spell mechanics, because

--- a/docs/tasks/spells/PACKAGE_3_ATLAS_GATE_CHECKPOINT_RECEIPT.md
+++ b/docs/tasks/spells/PACKAGE_3_ATLAS_GATE_CHECKPOINT_RECEIPT.md
@@ -1,0 +1,51 @@
+# Package 3 Atlas And Gate Checkpoint Receipt
+
+Status: pending Package 3 implementation.
+
+This receipt records spell validation, spell-gate, and Atlas evidence for the
+character creator and spellbook visibility slice.
+
+## Current State
+
+- Package 3 Symphony draft created: `no`
+- Package 3 Jules task dispatched: `no`
+- Package 3 implementation PR exists: `no`
+- Spell gate refresh run for Package 3: `not yet`
+- Atlas review/update run for Package 3: `not yet`
+- Can this receipt prove Package 3 gate completion yet: `no`
+
+Reason: Package 3 is currently being packaged for Jules. Gate proof belongs
+after Jules returns implementation output or after a bounded Codex repair.
+
+## Commands To Record After Package 3 Returns
+
+```powershell
+npm run validate:spells
+npm run generate:spell-gates
+npx vitest run src/components/CharacterCreator/__tests__/CharacterCreator.test.tsx src/components/CharacterSheet/__tests__/CharacterSheetModal.test.tsx --reporter=verbose
+```
+
+If a more focused test is added, record the exact command that ran.
+
+## Fields To Fill After The Checkpoint
+
+- Package 3 branch: `pending`
+- Package 3 PR: `pending`
+- Package 3 changed files: `pending`
+- `npm run validate:spells` result: `pending`
+- `npm run generate:spell-gates` result: `pending`
+- `public/data/spell_gate_report.json` changed: `pending`
+- Atlas surface checked or updated: `pending`
+- Visual proof receipt linked: `docs/tasks/spells/PACKAGE_3_VISUAL_PROOF_RECEIPT.md`
+- Follow-up bucket, combat, fixture, or AI arbitration work discovered:
+  `pending`
+- Can Package 4 begin after this checkpoint: `no`
+
+## Rules
+
+- Do not mark this receipt complete before Package 3 has real implementation
+  evidence.
+- If spell-gate generation changes only timestamps, record that and avoid
+  committing timestamp churn.
+- Do not use this receipt to claim combat simulator spell behavior; that belongs
+  to Package 4.

--- a/docs/tasks/spells/PACKAGE_3_DISPATCH_READINESS_CHECKLIST.md
+++ b/docs/tasks/spells/PACKAGE_3_DISPATCH_READINESS_CHECKLIST.md
@@ -1,0 +1,70 @@
+# Package 3 Dispatch Readiness Checklist
+
+Status: draft prepared; waiting for Symphony dashboard draft creation.
+
+This checklist guards the handoff from Codex foreman planning to a Jules-owned
+implementation task. It should be updated before dispatch, after Jules creates a
+PR, and during closeout.
+
+## Ready Artifacts
+
+- Phase 1 plan:
+  `docs/tasks/spells/EARLY_GAME_SPELL_EXECUTION_PLAN.md`
+- Living tracker:
+  `docs/tasks/spells/SPELL_PHASE_1_TASK_TRACKER.md`
+- Package 3 task:
+  `docs/tasks/spells/PACKAGE_3_SPELLBOOK_CREATOR_VISIBILITY_JULES_TASK.md`
+- Exact Jules prompt:
+  `docs/tasks/spells/PACKAGE_3_SPELLBOOK_CREATOR_VISIBILITY_JULES_PROMPT.md`
+- Symphony draft payload:
+  `docs/tasks/spells/PACKAGE_3_SYMPHONY_TASK_DRAFT_PAYLOAD.json`
+- Package 3 Atlas/gate receipt:
+  `docs/tasks/spells/PACKAGE_3_ATLAS_GATE_CHECKPOINT_RECEIPT.md`
+- Package 3 visual proof receipt:
+  `docs/tasks/spells/PACKAGE_3_VISUAL_PROOF_RECEIPT.md`
+- Decision report:
+  `conductor/symphony/docs/decision-reports/SPELL_PHASE_1_ASSUMED_APPROVAL_DECISIONS.md`
+
+## Pre-Dispatch State
+
+- Package 2 merged: `yes`, PR #935 merged as Package 2 implementation.
+- Package 2 closeout docs merged: `yes`, PR #938 recorded closeout.
+- Package 3 scope mapped: `yes`.
+- Symphony dashboard draft created: `no`.
+- Linear issue created: `not yet`.
+- Jules handoff launched: `no`.
+- Jules session id: `none`.
+- Package 3 implementation PR: `none`.
+
+## Reserved Names
+
+Recommended implementation branch:
+
+- `jules/spells-package3-spellbook-creator-visibility`
+
+Optional Codex review/repair branch:
+
+- `codex/spells-package3-spellbook-creator-visibility-review`
+
+Optional local review worktree:
+
+- `F:\Repos\Aralia\.worktrees\spells-package3-spellbook-creator-visibility`
+
+## Next Dispatch Steps
+
+1. Use the Symphony dashboard as the primary path to create the Package 3 task
+   draft from `PACKAGE_3_SYMPHONY_TASK_DRAFT_PAYLOAD.json`.
+2. If dashboard input blocks the visible flow, record the blocker and repair the
+   dashboard/workflow rather than silently posting to hidden endpoints.
+3. Create or link the Package 3 Linear issue if Symphony exposes that gate.
+4. Launch the Jules handoff from the visible task page once the draft passes its
+   gates.
+5. Record the draft id, handoff id, Jules session id, branch name, PR URL, and
+   verifier output in this checklist and the Package 3 receipts.
+
+## Abort Or Repair Path
+
+If Package 3 uncovers a broad assembly, class-rule, or spellbook data-model
+decision, record it in the decision report before allowing Jules to broaden the
+slice. If the decision belongs to combat simulator casting or AI arbitration,
+record it as a Package 4 or Package 5 gap instead of expanding Package 3.

--- a/docs/tasks/spells/PACKAGE_3_SPELLBOOK_CREATOR_VISIBILITY_JULES_PROMPT.md
+++ b/docs/tasks/spells/PACKAGE_3_SPELLBOOK_CREATOR_VISIBILITY_JULES_PROMPT.md
@@ -1,0 +1,68 @@
+# Package 3 Jules Prompt: Spellbook And Character Creator Visibility
+
+You are implementing Spell Phase 1 Package 3 in Aralia.
+
+Goal: make early-game spell selection and spellbook inspection clear and
+trustworthy for players. Focus on cantrips and level 1 spell selection in the
+character creator, plus the character sheet spellbook display for cantrips,
+prepared spells, known/unprepared spells, always-prepared spells, and spell
+slots.
+
+Read first:
+
+- `docs/tasks/spells/PACKAGE_3_SPELLBOOK_CREATOR_VISIBILITY_JULES_TASK.md`
+- `docs/tasks/spells/EARLY_GAME_SPELL_EXECUTION_PLAN.md`
+- `docs/tasks/spells/SPELL_PHASE_1_TASK_TRACKER.md`
+- `docs/tasks/spells/PACKAGE_2_ATLAS_GATE_CHECKPOINT_RECEIPT.md`
+- `docs/tasks/spells/PACKAGE_2_FOREMAN_REVIEW_RECEIPT.md`
+
+Expected implementation areas:
+
+- `src/components/CharacterCreator/Class/*FeatureSelection.tsx`
+- `src/components/CharacterCreator/CharacterCreator.tsx`
+- `src/components/CharacterCreator/hooks/useCharacterAssembly.ts`
+- `src/components/CharacterCreator/state/characterCreatorState.ts`
+- `src/components/CharacterSheet/CharacterSheetModal.tsx`
+- `src/components/CharacterSheet/Spellbook/*.tsx`
+- focused tests under the nearest existing `__tests__` directory
+
+Do:
+
+- keep spell selection class-legal and level-legal
+- preserve selection limits and make counts/states clear
+- make spell choice cards useful without raw schema labels
+- make prepared/unprepared/cantrip/always-prepared states visible in the
+  spellbook
+- make sure selected spells survive character assembly
+- add or update focused tests for the creator and spellbook paths
+- run spell validation and spell-gate generation and report whether generated
+  files changed
+
+Do not:
+
+- implement combat simulator spell casting in this package
+- change broad spell schema/runtime architecture
+- set broad AI arbitration policy
+- change premade roster semantics except for tiny test fixtures if absolutely
+  necessary
+- edit Symphony orchestration files
+- claim level 2-3 combat coverage from this UI package
+
+Verification commands:
+
+```powershell
+npm run validate:spells
+npm run generate:spell-gates
+npx vitest run src/components/CharacterCreator/__tests__/CharacterCreator.test.tsx src/components/CharacterSheet/__tests__/CharacterSheetModal.test.tsx --reporter=verbose
+```
+
+If you add a more focused test file, run it too and report the exact command.
+
+Completion report should include:
+
+- changed files
+- behavior summary
+- how known/prepared spellbook semantics work after your change
+- verification commands and results
+- screenshots or test proof for the creator and spellbook flows
+- any adjacent gaps found for Package 4, Package 5, or later mechanics buckets

--- a/docs/tasks/spells/PACKAGE_3_SPELLBOOK_CREATOR_VISIBILITY_JULES_TASK.md
+++ b/docs/tasks/spells/PACKAGE_3_SPELLBOOK_CREATOR_VISIBILITY_JULES_TASK.md
@@ -1,0 +1,157 @@
+# Package 3 Jules Task: Spellbook And Character Creator Visibility
+
+Status: package draft prepared for Symphony dashboard intake.
+
+This is the next Spell Phase 1 implementation slice after Package 2 merged the
+premade level-1 party gear and caster legality work. Package 3 is intentionally
+player-facing: it should make early-game spell choices understandable in the
+character creator and make the character sheet spellbook readable enough that a
+player can trust what is known, prepared, always prepared, or merely available.
+
+## Worker
+
+Default worker: Jules.
+
+Codex role: foreman. Codex owns scoping, dashboard handoff, review,
+verification, decision reporting, and Atlas/gate receipts. Jules should own the
+implementation-heavy UI, assembly, and focused test work once the Symphony task
+is created.
+
+## Branch And Worktree
+
+Recommended implementation branch:
+
+- `jules/spells-package3-spellbook-creator-visibility`
+
+Optional Codex review/repair branch, only if a bounded local follow-up is safer
+than returning the PR to Jules:
+
+- `codex/spells-package3-spellbook-creator-visibility-review`
+
+Recommended local review worktree:
+
+- `F:\Repos\Aralia\.worktrees\spells-package3-spellbook-creator-visibility`
+
+## Goal
+
+Make cantrips and level 1 spell choices pleasant, legible, and rules-aware in
+the character creator and character sheet spellbook, while preserving the Phase
+1 plan for level 2-3 spell support in later combat and fixture packages.
+
+## Source Context
+
+Use these existing artifacts instead of inventing a parallel plan:
+
+- `docs/tasks/spells/EARLY_GAME_SPELL_EXECUTION_PLAN.md`
+- `docs/tasks/spells/SPELL_PHASE_1_TASK_TRACKER.md`
+- `docs/tasks/spells/SPELL_PHASE_1_BASELINE_REPORT.md`
+- `docs/tasks/spells/PACKAGE_2_ATLAS_GATE_CHECKPOINT_RECEIPT.md`
+- `docs/tasks/spells/PACKAGE_2_FOREMAN_REVIEW_RECEIPT.md`
+- `src/components/CharacterCreator/Class/*FeatureSelection.tsx`
+- `src/components/CharacterCreator/hooks/useCharacterAssembly.ts`
+- `src/components/CharacterCreator/state/characterCreatorState.ts`
+- `src/components/CharacterSheet/CharacterSheetModal.tsx`
+- `src/components/CharacterSheet/Spellbook/SpellbookTab.tsx`
+- `src/components/CharacterSheet/Spellbook/SpellbookOverlay.tsx`
+- `src/components/CharacterSheet/Spellbook/SpellDetailPane.tsx`
+
+## Ownership
+
+Jules may edit:
+
+- `src/components/CharacterCreator/Class/*FeatureSelection.tsx`
+- `src/components/CharacterCreator/CharacterCreator.tsx`
+- `src/components/CharacterCreator/hooks/useCharacterAssembly.ts`
+- `src/components/CharacterCreator/state/characterCreatorState.ts`
+- `src/components/CharacterCreator/__tests__/*.test.tsx`
+- `src/components/CharacterCreator/Class/__tests__/*.test.tsx`
+- `src/components/CharacterSheet/CharacterSheetModal.tsx`
+- `src/components/CharacterSheet/Spellbook/*.tsx`
+- `src/components/CharacterSheet/__tests__/*.test.tsx`
+- the nearest existing focused test file if a better local convention exists
+
+Jules should not edit:
+
+- combat simulator casting behavior or spell command runtime
+- broad spell JSON schema or shared runtime architecture
+- AI arbitration policy
+- premade character roster semantics, except tiny fixture adjustments strictly
+  needed for a UI test
+- Symphony orchestration files
+- higher-level spell mechanics buckets
+
+## Current Observations
+
+- Several class feature selectors already show cantrip and level 1 spell
+  choices, but the cards mostly expose spell name and damage dice only.
+- The selectors repeat similar card/count logic across Bard, Cleric, Druid,
+  Sorcerer, Warlock, Wizard, Paladin, and Ranger surfaces.
+- `useCharacterAssembly.ts` currently places selected level 1 spells in
+  `preparedSpells`, while `knownSpells` can include the whole class spell list.
+  If that is intentional for discovery, the UI must make prepared vs available
+  distinction clear. If it is not intentional, repair the assembly model within
+  this slice and explain the behavior change.
+- `CharacterSheetModal.tsx` already exposes a Spellbook tab when spellbook data
+  exists.
+- `SpellbookTab.tsx` already distinguishes cantrips, prepared, unprepared, and
+  always-prepared states, but this needs focused UI/test proof and cleanup of
+  player-facing rough edges such as compact labels or mojibake.
+- `SpellbookOverlay.tsx` has similar spellbook behavior and should not drift
+  from the tab if it remains a live surface.
+
+## Required Work
+
+1. Improve character creator spell choice cards for caster classes so players
+   can compare cantrips and level 1 spells without opening raw data. Include
+   useful player-facing facts such as level, school, casting time, range,
+   concentration/ritual tags, damage/healing summaries where available, and
+   readable prepared/known language.
+2. Keep class and level filtering strict. Cantrip lists must only show level 0
+   spells and level 1 lists must only show level 1 spells from the relevant
+   class spell list.
+3. Preserve and clarify selection limits. Counts must stay visible, disabled
+   states must make sense, and completed selections must survive character
+   assembly.
+4. Review `useCharacterAssembly.ts` for known/prepared spellbook semantics. Do
+   not silently give created casters every spell as prepared. If the current
+   model intentionally keeps full class access in `knownSpells`, make the UI
+   label that as available/unprepared rather than selected/prepared.
+5. Improve the character sheet spellbook display enough that cantrips,
+   prepared spells, unprepared/known spells, always-prepared spells, and slots
+   are visually distinguishable without raw schema or debug labels.
+6. Keep the UI consistent with existing Aralia styling. Avoid a landing-page or
+   marketing redesign; this is an in-app utility surface.
+7. Add focused tests or screenshots/manual proof for the core flows:
+   character creator spell selection, assembly persistence, Spellbook tab
+   visibility, and spellbook prepared/unprepared state rendering.
+8. Run and record spell-gate validation even if no spell JSON changes. If the
+   gate report only changes timestamps, record that and do not commit timestamp
+   churn.
+
+## Verification Commands
+
+Jules should run the narrowest relevant checks first:
+
+```powershell
+npm run validate:spells
+npm run generate:spell-gates
+npx vitest run src/components/CharacterCreator/__tests__/CharacterCreator.test.tsx src/components/CharacterSheet/__tests__/CharacterSheetModal.test.tsx --reporter=verbose
+```
+
+If Jules adds a more focused test file, include it in the vitest command and
+record the exact command in the completion note.
+
+## Acceptance Criteria
+
+- Character creator spell selection remains class-legal and level-legal.
+- Spell cards expose enough player-facing detail for meaningful choices without
+  raw JSON/debug field names.
+- Selected cantrips and level 1 spells survive character assembly.
+- Prepared, unprepared/known, always-prepared, cantrip, and slot states are
+  visible in the character sheet spellbook.
+- No caster is represented as having every spell prepared.
+- Focused tests or rendered proof cover the creator and spellbook flows.
+- Atlas/gate receipt for Package 3 records validation output and whether any
+  generated report changed.
+- Any level 2-3 fixture, combat simulator, or AI arbitration issue discovered
+  here is recorded as a follow-up gap instead of folded into this UI slice.

--- a/docs/tasks/spells/PACKAGE_3_SYMPHONY_TASK_DRAFT_PAYLOAD.json
+++ b/docs/tasks/spells/PACKAGE_3_SYMPHONY_TASK_DRAFT_PAYLOAD.json
@@ -1,0 +1,24 @@
+{
+  "status": "draft_ready_for_dashboard_creation",
+  "submittedDraftId": null,
+  "submittedAt": null,
+  "endpoint": "POST /api/v1/task-drafts",
+  "title": "Spell Phase 1 Package 3: spellbook and character creator visibility",
+  "body": "Use the exact Jules prompt packet in docs/tasks/spells/PACKAGE_3_SPELLBOOK_CREATOR_VISIBILITY_JULES_PROMPT.md. Scope: improve cantrip and level 1 spell selection in the character creator and make the character sheet spellbook clearly show cantrips, prepared spells, known/unprepared spells, always-prepared spells, and slots. Worker: Jules. Branch: jules/spells-package3-spellbook-creator-visibility. Do not broaden into combat simulator casting behavior, broad spell schema/runtime architecture, AI arbitration policy, premade roster semantics, or Symphony orchestration files. Record any level 2-3 fixture, combat, or arbitration discoveries as follow-up gaps.",
+  "expectedFiles": [
+    "src/components/CharacterCreator/Class/*FeatureSelection.tsx",
+    "src/components/CharacterCreator/CharacterCreator.tsx",
+    "src/components/CharacterCreator/hooks/useCharacterAssembly.ts",
+    "src/components/CharacterCreator/state/characterCreatorState.ts",
+    "src/components/CharacterCreator/__tests__/*.test.tsx",
+    "src/components/CharacterCreator/Class/__tests__/*.test.tsx",
+    "src/components/CharacterSheet/CharacterSheetModal.tsx",
+    "src/components/CharacterSheet/Spellbook/*.tsx",
+    "src/components/CharacterSheet/__tests__/*.test.tsx"
+  ],
+  "verificationCommands": [
+    "npm run validate:spells",
+    "npm run generate:spell-gates",
+    "npx vitest run src/components/CharacterCreator/__tests__/CharacterCreator.test.tsx src/components/CharacterSheet/__tests__/CharacterSheetModal.test.tsx --reporter=verbose"
+  ]
+}

--- a/docs/tasks/spells/PACKAGE_3_VISUAL_PROOF_RECEIPT.md
+++ b/docs/tasks/spells/PACKAGE_3_VISUAL_PROOF_RECEIPT.md
@@ -1,0 +1,40 @@
+# Package 3 Visual Proof Receipt
+
+Status: pending Package 3 implementation.
+
+This receipt records the rendered or test-backed proof that Package 3 improved
+the player-facing spell selection and spellbook surfaces.
+
+## Required Proof
+
+- Character creator spell selection proof:
+  - class checked: `pending`
+  - cantrip and level 1 spell cards visible: `pending`
+  - selection counts and disabled states visible or tested: `pending`
+  - selected spells survive assembly: `pending`
+- Character sheet spellbook proof:
+  - Spellbook tab visible for a caster: `pending`
+  - cantrip state visible: `pending`
+  - prepared state visible: `pending`
+  - unprepared/known state visible: `pending`
+  - always-prepared state visible where applicable: `pending`
+  - spell slots/prepared count visible: `pending`
+- Proof type:
+  - screenshot paths: `pending`
+  - component test names: `pending`
+  - manual rendered inspection notes: `pending`
+
+## Current Notes
+
+Package 3 has not been dispatched yet. This file exists so Jules and Codex have
+a durable place to attach UI proof instead of treating screenshots or component
+test output as transient terminal context.
+
+## Rules
+
+- Do not claim visual completion from source edits alone.
+- If screenshots are not feasible in Jules, require focused component tests and
+  Codex rendered inspection during foreman review.
+- If the character creator or spellbook surface cannot render because of an
+  unrelated blocker, record that blocker and classify whether it belongs in
+  Package 3 or a follow-up.

--- a/docs/tasks/spells/SPELL_PHASE_1_TASK_TRACKER.md
+++ b/docs/tasks/spells/SPELL_PHASE_1_TASK_TRACKER.md
@@ -50,17 +50,19 @@ Statuses:
   `https://github.com/Gambitnl/Aralia/pull/936`
 - Package 2 setup-review workflow repair PR:
   `https://github.com/Gambitnl/Aralia/pull/937`
+- Package 2 closeout PR:
+  `https://github.com/Gambitnl/Aralia/pull/938`
 
 ## Active Package Queue
 
 | ID | Status | Owner | Task | Detail file | Current boundary |
 |---|---|---|---|---|---|
-| P0 | active | Codex foreman | Symphony finalization baseline: post-ARA-6 contract, stale-status cleanup, branch/worktree discipline, decision reporting, task evidence pathways, artifact lifecycle rules | `EARLY_GAME_SPELL_EXECUTION_PLAN.md`, `SPELL_PHASE_1_ARTIFACT_LIFECYCLE_POLICY.md` | Setup PR #933 landed; continue evidence updates during Package 2 |
+| P0 | active | Codex foreman | Symphony finalization baseline: post-ARA-6 contract, stale-status cleanup, branch/worktree discipline, decision reporting, task evidence pathways, artifact lifecycle rules | `EARLY_GAME_SPELL_EXECUTION_PLAN.md`, `SPELL_PHASE_1_ARTIFACT_LIFECYCLE_POLICY.md` | Setup PR #933 and Package 2 workflow/closeout PRs have landed; continue evidence updates during Package 3 |
 | P1 | done | Codex foreman | Scoped baseline inventory for levels 0-3 | `SPELL_PHASE_1_BASELINE_REPORT.md` | Baseline report exists; use as context for later packages |
 | P2 | done | Jules implementation, Codex foreman review | Premade level-1 party gear, combat readiness, and caster spellbook legality | `PACKAGE_2_PREMADE_PARTY_GEAR_JULES_TASK.md`, `PACKAGE_2_PREMADE_PARTY_GEAR_JULES_PROMPT.md`, `PACKAGE_2_DISPATCH_READINESS_CHECKLIST.md`, `PACKAGE_2_SYMPHONY_HANDOFF_RECEIPT.md`, `PACKAGE_2_PR_DEPLOYMENT_LOCAL_SYNC_RECEIPT.md` | PR #935 merged on 2026-05-22 after PR #937 repaired the review workflow, the PR branch was updated with current `master`, GitHub CI reran clean, and post-merge local gate checks passed on the closeout branch |
 | P2D | done | Codex foreman | Dashboard-first hardening for Package 2 handoff monitoring | `PACKAGE_2_SYMPHONY_HANDOFF_RECEIPT.md`; Decisions 26-42; PR #936; PR #937 | Dashboard-first Package 2 blockers exposed useful repairs: safe PR refresh buttons, Scout/Core glob handling, visible operator decision buttons, setup-repair lane routing, global PR boundary routing, Git Safety visibility, current-boundary action buttons, and first-viewport focus strip; Stitch MCP server entry exists but still needs authentication/restart before Stitch-generated redesigns can be used |
 | P2R | done | Codex foreman local-careful | Workflow-config repair lane for PR #935 failed `review / review` automation | local draft `draft-1779410025252-nnowpt` (`Setup repair for ARA-7`); Decisions 38, 40, 41; PR #937 | PR #937 merged, PR #935 branch was updated against current `master`, rerun CI passed, and PR #935 then merged |
-| P3 | active | Jules preferred after P2 | Character creator spell selection and character sheet spellbook visibility | create `PACKAGE_3_*` docs from the Phase 1 plan and Package 2 closeout | Package 2 is merged; next dashboard-first boundary is Package 3 task packaging and Jules offload |
+| P3 | active | Jules preferred after dashboard draft | Character creator spell selection and character sheet spellbook visibility | `PACKAGE_3_SPELLBOOK_CREATOR_VISIBILITY_JULES_TASK.md`, `PACKAGE_3_SPELLBOOK_CREATOR_VISIBILITY_JULES_PROMPT.md`, `PACKAGE_3_DISPATCH_READINESS_CHECKLIST.md`, `PACKAGE_3_SYMPHONY_TASK_DRAFT_PAYLOAD.json`, `PACKAGE_3_ATLAS_GATE_CHECKPOINT_RECEIPT.md`, `PACKAGE_3_VISUAL_PROOF_RECEIPT.md` | Package 3 task packet is drafted; next dashboard-first boundary is creating the Symphony dashboard draft visibly |
 | P4 | not_started | Jules preferred after P3 | Combat simulator deterministic spell pilot | create `PACKAGE_4_*` docs after P3 | Waiting on P2/P3 |
 | P5 | not_started | Jules preferred after P4 | AI arbitration pilot for open-ended spells | create `PACKAGE_5_*` docs after deterministic pilot | Waiting on P4 |
 | P6 | not_started | Jules preferred after pilots | First mechanics bucket closure for levels 0-3 | create bucket-specific docs from current mechanics-discovery evidence | Waiting on pilot evidence |
@@ -105,22 +107,32 @@ package queue or a linked detailed task file.
 | G18 | done | Current-boundary PR review | The top `Current Foreman Boundary` said `Run GitHub PR` with `Method POST` and `Can run now yes`, but rendered only raw links instead of the existing safe PR-refresh button | This was a dashboard affordance bug; using the raw POST endpoint or hunting for a lower duplicate button would weaken the dashboard-first workflow | Decision 37; `conductor/symphony/public/dashboard.js`; `conductor/symphony/scripts/verify-pr-boundary-after-jules-completion.mjs`; current-boundary PR refresh now renders as `Refresh GitHub PR` |
 | G19 | done | Setup-repair draft execution | The generated setup-repair draft expected `package-lock.json`, `package.json`, and `.github/workflows/ci.yml`, but the actual PR #935 review failure was in `.github/workflows/gemini-review.yml` and the repository lacked a current `GEMINI_MODEL` variable | This was a Symphony setup-repair scoping gap plus a GitHub repository configuration gap; the fix updates future repair draft scope and records why the live repair intentionally touched `gemini-review.yml` | Decisions 38, 43; PR #937 merged; repository variable `GEMINI_MODEL=gemini-2.5-flash`; PR #938 review rerun passed |
 | G20 | done | PR #935 failed test classification | GitHub full-suite Tests failed `handleMovement - Seasonal Effects > increases travel time in Winter`, expected `2700`, got `8100`; the focused `handleMovement.test.ts` passed locally on synced `master` | This was outside Package 2 write scope and outside the workflow-model repair; rerun after PR #935 branch update passed | Classified as rerun-cleared/ambient for Package 2 |
-| G21 | active | Dashboard redesign request | The operator asked to use Stitch for dashboard UX, but the running Codex session had no Stitch MCP tools and no local Stitch API key; a user-level Stitch MCP server entry was added, but authentication and restart are still required | This is a tooling/authentication gap for future design iteration, not a reason to mislabel local dashboard edits as Stitch-generated | Decision 39; `C:\Users\Gambit\.codex\config.toml`; next step is add Stitch API key/OAuth headers, restart Codex, then confirm Stitch tools are visible |
+| G21 | active | Dashboard redesign request | The operator asked to use Stitch for dashboard UX; the Stitch settings page exposed an existing masked API key that Codex could not recover, so Codex configured the local Stitch MCP proxy through Google Cloud application credentials instead | This is a tooling/authentication gap for future design iteration, not a reason to mislabel local dashboard edits as Stitch-generated | Decision 39; `C:\Users\Gambit\.codex\config.toml`; `npm run stitch:doctor` passed after the local proxy/Windows gcloud wrapper setup; restart Codex and confirm Stitch tools use the proxy before claiming Stitch-generated design work |
 | G22 | done | Main dashboard first-viewport review | Even after earlier compaction, the dashboard still required too much scanning before the active boundary/action was obvious | This is dashboard workflow UX, adjacent to Package 2 spell implementation but directly required by the dashboard-first goal | Decision 39; `conductor/symphony/public/dashboard.js`; `conductor/symphony/public/dashboard.css`; dashboard contract checks and rendered browser inspection passed locally; PR #937 merged |
+| G23 | done | Package 2 closeout to Package 3 setup | Some Package 2 detailed-file statuses stayed active after PR #935, PR #937, and PR #938 merged | This was a tracking/documentation drift issue, not an implementation blocker; stale tracker text can mislead future agents and dashboard task scoping | Package 3 planning update reconciled Package 2 detailed-file statuses and made Package 3 the active slice |
+| G24 | active | Package 3 planning | Current character creator assembly may place the full class spell list in `knownSpells` while selected level 1 spells become `preparedSpells` | This may be intentional spell availability modeling, but it can make the UI look like every class spell belongs to the character if labels are unclear | Package 3 task requires Jules to preserve or repair the distinction and document the resulting known/prepared semantics |
+| G25 | active | Package 3 planning | Spellbook and spell creator surfaces need rendered proof, not just source edits | Visual verification belongs in Package 3; Package 2 deliberately did not claim this proof | `PACKAGE_3_VISUAL_PROOF_RECEIPT.md` |
+| G26 | active | Package 3 dashboard Git gate | The dashboard Git sync plan suggested pushing/pulling local `master` even though local-only `master` commits are unrelated racial-mechanics work and the active Package 3 docs are on a package branch | This is a Symphony workflow-guidance gap exposed by dashboard-first use; the agent recorded dispositions visibly and chose a non-destructive branch publication path instead of following the unsafe master-oriented suggestion | Decision 45; future dashboard refinement should support publishing a planning branch or changing the intended base without implying unrelated `master` commits should be pushed |
 
 ## Detailed Task File Index
 
 | File | Purpose | Status |
 |---|---|---|
-| `PACKAGE_2_PREMADE_PARTY_GEAR_JULES_TASK.md` | Package 2 scope and acceptance criteria | active, blocked before Jules dispatch |
-| `PACKAGE_2_PREMADE_PARTY_GEAR_JULES_PROMPT.md` | Exact Jules prompt for Package 2 | prompt-ready, not dispatched |
-| `PACKAGE_2_DISPATCH_READINESS_CHECKLIST.md` | Handoff guard for Package 2 | active |
-| `PACKAGE_2_ATLAS_GATE_CHECKPOINT_RECEIPT.md` | Package 2 Atlas/gate proof target | pending implementation |
-| `PACKAGE_2_FOREMAN_REVIEW_RECEIPT.md` | Package 2 Codex review/failure classification target | pending implementation |
-| `PACKAGE_2_TASK_COMMUNICATION_RECEIPT.md` | Package 2 task-scoped communication target | pending implementation |
-| `PACKAGE_2_PR_DEPLOYMENT_LOCAL_SYNC_RECEIPT.md` | Package 2 PR/deployment/local-sync target | pending implementation |
+| `PACKAGE_2_PREMADE_PARTY_GEAR_JULES_TASK.md` | Package 2 scope and acceptance criteria | done; historical scope packet |
+| `PACKAGE_2_PREMADE_PARTY_GEAR_JULES_PROMPT.md` | Exact Jules prompt for Package 2 | done; dispatched through Symphony/Jules |
+| `PACKAGE_2_DISPATCH_READINESS_CHECKLIST.md` | Handoff guard for Package 2 | done; handoff and PR lifecycle completed |
+| `PACKAGE_2_ATLAS_GATE_CHECKPOINT_RECEIPT.md` | Package 2 Atlas/gate proof target | done for Package 2 |
+| `PACKAGE_2_FOREMAN_REVIEW_RECEIPT.md` | Package 2 Codex review/failure classification target | superseded by merge closeout; older blocker details retained |
+| `PACKAGE_2_TASK_COMMUNICATION_RECEIPT.md` | Package 2 task-scoped communication target | done for Package 2 |
+| `PACKAGE_2_PR_DEPLOYMENT_LOCAL_SYNC_RECEIPT.md` | Package 2 PR/deployment/local-sync target | done for Package 2 |
 | `SPELL_PHASE_1_ARTIFACT_LIFECYCLE_POLICY.md` | Retain/archive/delete policy for package artifacts | active |
-| `PACKAGE_2_SYMPHONY_HANDOFF_RECEIPT.md` | Clean-base Package 2 draft, Linear issue, handoff, manifest, Jules launch, PR #935, and scoped verification receipt | active, PR review in progress |
+| `PACKAGE_2_SYMPHONY_HANDOFF_RECEIPT.md` | Clean-base Package 2 draft, Linear issue, handoff, manifest, Jules launch, PR #935, and scoped verification receipt | done for Package 2 |
+| `PACKAGE_3_SPELLBOOK_CREATOR_VISIBILITY_JULES_TASK.md` | Package 3 scope and acceptance criteria | active draft |
+| `PACKAGE_3_SPELLBOOK_CREATOR_VISIBILITY_JULES_PROMPT.md` | Exact Jules prompt for Package 3 | prompt-ready, not dispatched |
+| `PACKAGE_3_DISPATCH_READINESS_CHECKLIST.md` | Handoff guard for Package 3 | active |
+| `PACKAGE_3_SYMPHONY_TASK_DRAFT_PAYLOAD.json` | Dashboard draft payload for Package 3 | draft-ready |
+| `PACKAGE_3_ATLAS_GATE_CHECKPOINT_RECEIPT.md` | Package 3 Atlas/gate proof target | pending implementation |
+| `PACKAGE_3_VISUAL_PROOF_RECEIPT.md` | Package 3 rendered/test visual proof target | pending implementation |
 
 ## Update Rules
 


### PR DESCRIPTION
## Summary
- add Package 3 Jules task, prompt, dashboard payload, readiness checklist, and proof receipts
- update the Spell Phase 1 tracker to make Package 3 the active slice
- record decisions for Package 3 packaging and the dashboard Git-sync disposition blocker

## Verification
- Package 3 payload JSON valid
- git diff --cached --check
- npm run verify:jules-contract

## Dashboard notes
- Dashboard-first flow reached the Git Safety gate before task draft creation.
- Recorded visible dispositions: local-only master commits keep local; Package 3 docs commit for Jules base.
- Did not push or reset local master because it contains unrelated racial-mechanics work.