### PR TITLE
[codex] Record Package 3 Jules launch

### DIFF
--- a/conductor/symphony/docs/decision-reports/SPELL_PHASE_1_ASSUMED_APPROVAL_DECISIONS.md
+++ b/conductor/symphony/docs/decision-reports/SPELL_PHASE_1_ASSUMED_APPROVAL_DECISIONS.md
@@ -1938,13 +1938,59 @@ Copy this block for each decision.
   `8139`, record the current branch disposition visibly if still needed, and
   continue to Package 3 draft creation only after the Git gate reports ready.
 
+### Decision 49: Dispatch Package 3 Through The Visible Dashboard Flow
+
+- Date/time: 2026-05-22
+- Phase: `package_3_dashboard_dispatch`
+- Active slice: Package 3 spellbook and character creator visibility
+- Decision point: With PR #941 merged and the dashboard Git gate reporting
+  ready, the operator-facing choice was whether to continue Package 3 through
+  the visible dashboard controls or use terminal/API endpoints to create the
+  draft, Linear issue, handoff, manifest, and Jules launch faster.
+- Options considered:
+  - Use hidden API calls because the draft and handoff controls were available
+    as known endpoints.
+  - Pause Package 3 dispatch and repair the dashboard before any further
+    progress.
+  - Use the visible dashboard controls, reopening the relevant drawer when the
+    dashboard rerender collapsed it, and record that drawer friction as a UX
+    gap rather than a dispatch blocker.
+- Decision made by agent: Use the visible dashboard controls and continue
+  dispatch while recording the collapsed-drawer friction as an adjacent
+  Symphony UX gap.
+- Model routing: Local Codex foreman for orchestration and evidence capture;
+  Jules receives the implementation task itself.
+- Rationale/evidence: The dashboard showed Package 3 in the task navigator and
+  the `Task Intake And Records` drawer contained the correct enabled controls.
+  The visible `Prepare Handoff`, `Stage Jules Manifest`, `Launch Jules`, and
+  current-boundary `Refresh Jules Status` buttons all worked once the relevant
+  drawer/control was visible. Using hidden POST endpoints would have skipped
+  the dashboard-first pressure test the operator explicitly requested.
+- Mutation performed or skipped: Created dashboard draft
+  `draft-1779442977969-w2vsy4`, attached Linear issue ARA-9, promoted handoff
+  `handoff-1779443555192-bnpws7`, staged its manifest, launched Jules session
+  `2823658242418460192`, and refreshed status through the dashboard. Did not
+  bypass any blocked dashboard step with direct endpoint calls.
+- Scope guardrails: Package 3 remains limited to character creator spell
+  selection and character sheet spellbook visibility. Combat simulator casting,
+  broad spell schema/runtime architecture, AI arbitration policy, and premade
+  roster semantics remain later packages or adjacent gaps unless needed only as
+  tiny test fixtures.
+- Result: Jules reports `QUEUED`; no PR URL has been captured yet. The Package
+  3 handoff receipt and readiness checklist now carry the draft, Linear,
+  handoff, manifest, and session ids.
+- Next expected proof: Continue refreshing Jules status through the dashboard
+  until Symphony captures a PR URL, a plan-approval gate, a feedback request, or
+  a durable reason that Jules has not produced a PR yet.
+
 ## Open Decisions For The Next Slice
 
-1. Create the Package 3 Symphony dashboard draft visibly from
-   `PACKAGE_3_SYMPHONY_TASK_DRAFT_PAYLOAD.json`.
-2. Package and dispatch Package 3 for Jules: character creator spell selection
-   and character sheet spellbook visibility.
-3. Land the scoped Git-disposition repair if checks pass, then clear the
-   current branch from the dashboard Git gate through the visible workflow.
+1. Monitor Package 3 Jules session `2823658242418460192` through the visible
+   dashboard until it exposes a PR, plan approval, feedback need, or durable
+   no-PR state.
+2. Review any Package 3 PR for scope, focused tests, rendered spellbook/creator
+   proof, Atlas/gate checkpoint updates, and adjacent gaps before merge.
+3. Decide whether to repair the task-navigator/drawer UX so selecting or acting
+   on a task opens the `Task Intake And Records` group automatically.
 4. Repair the Stitch MCP/OAuth/tool path before claiming any Stitch-generated
    dashboard redesign work.

--- a/docs/tasks/spells/PACKAGE_3_DISPATCH_READINESS_CHECKLIST.md
+++ b/docs/tasks/spells/PACKAGE_3_DISPATCH_READINESS_CHECKLIST.md
@@ -1,6 +1,6 @@
 # Package 3 Dispatch Readiness Checklist
 
-Status: draft prepared; waiting for Symphony dashboard draft creation.
+Status: launched to Jules; waiting for PR capture.
 
 This checklist guards the handoff from Codex foreman planning to a Jules-owned
 implementation task. It should be updated before dispatch, after Jules creates a
@@ -22,6 +22,8 @@ PR, and during closeout.
   `docs/tasks/spells/PACKAGE_3_ATLAS_GATE_CHECKPOINT_RECEIPT.md`
 - Package 3 visual proof receipt:
   `docs/tasks/spells/PACKAGE_3_VISUAL_PROOF_RECEIPT.md`
+- Package 3 Symphony handoff receipt:
+  `docs/tasks/spells/PACKAGE_3_SYMPHONY_HANDOFF_RECEIPT.md`
 - Decision report:
   `conductor/symphony/docs/decision-reports/SPELL_PHASE_1_ASSUMED_APPROVAL_DECISIONS.md`
 
@@ -30,10 +32,16 @@ PR, and during closeout.
 - Package 2 merged: `yes`, PR #935 merged as Package 2 implementation.
 - Package 2 closeout docs merged: `yes`, PR #938 recorded closeout.
 - Package 3 scope mapped: `yes`.
-- Symphony dashboard draft created: `no`.
-- Linear issue created: `not yet`.
-- Jules handoff launched: `no`.
-- Jules session id: `none`.
+- Symphony dashboard draft created: `yes`, `draft-1779442977969-w2vsy4`.
+- Linear issue created: `yes`, ARA-9:
+  `https://linear.app/aralia/issue/ARA-9/spell-phase-1-package-3-spellbook-and-character-creator-visibility`.
+- Symphony handoff prepared: `yes`, `handoff-1779443555192-bnpws7`.
+- Jules manifest staged: `yes`,
+  `.jules/runs/symphony-handoff-1779443555192-bnpws7/manifest.json`.
+- Jules handoff launched: `yes`.
+- Jules session id: `2823658242418460192`.
+- Jules session state: `QUEUED` as of the dashboard refresh at
+  2026-05-22 11:54 local time.
 - Package 3 implementation PR: `none`.
 
 ## Reserved Names
@@ -52,15 +60,17 @@ Optional local review worktree:
 
 ## Next Dispatch Steps
 
-1. Use the Symphony dashboard as the primary path to create the Package 3 task
-   draft from `PACKAGE_3_SYMPHONY_TASK_DRAFT_PAYLOAD.json`.
-2. If dashboard input blocks the visible flow, record the blocker and repair the
-   dashboard/workflow rather than silently posting to hidden endpoints.
-3. Create or link the Package 3 Linear issue if Symphony exposes that gate.
-4. Launch the Jules handoff from the visible task page once the draft passes its
-   gates.
-5. Record the draft id, handoff id, Jules session id, branch name, PR URL, and
-   verifier output in this checklist and the Package 3 receipts.
+1. Refresh Jules status through the visible dashboard until Symphony captures a
+   PR URL or records why no PR exists yet.
+2. If Jules asks for plan approval or feedback, use the dashboard/Jules visible
+   path and record the decision before continuing.
+3. When a PR appears, run the Package 3 review path before Scout/Core merge:
+   scope check, relevant focused tests, visual proof, Atlas/gate checkpoint,
+   and PR checks.
+4. Record the PR URL, verifier output, visual proof, and Atlas/gate checkpoint
+   in this checklist and the Package 3 receipts.
+5. Keep combat simulator casting and AI arbitration discoveries as Package 4/5
+   gaps unless they are tiny fixture-only changes required to test Package 3.
 
 ## Abort Or Repair Path
 

--- a/docs/tasks/spells/PACKAGE_3_SYMPHONY_HANDOFF_RECEIPT.md
+++ b/docs/tasks/spells/PACKAGE_3_SYMPHONY_HANDOFF_RECEIPT.md
@@ -1,0 +1,50 @@
+# Package 3 Symphony Handoff Receipt
+
+Status: launched to Jules; waiting for PR capture.
+
+This receipt records the dashboard-first path from the Package 3 planning
+packet to an active Jules session. It exists so future foremen do not need to
+infer the handoff state from transient dashboard JSON or terminal scrollback.
+
+## Task Identity
+
+- Package: Spell Phase 1 Package 3
+- Scope: character creator spell selection and character sheet spellbook
+  visibility for cantrips and level 1 spell use surfaces.
+- Dashboard draft id: `draft-1779442977969-w2vsy4`
+- Linear issue: `ARA-9`
+- Linear URL:
+  `https://linear.app/aralia/issue/ARA-9/spell-phase-1-package-3-spellbook-and-character-creator-visibility`
+- Symphony handoff id: `handoff-1779443555192-bnpws7`
+- Jules session id: `2823658242418460192`
+- Jules session URL: `https://jules.google.com/session/2823658242418460192`
+- Requested Jules branch:
+  `jules/spells-package3-spellbook-creator-visibility`
+
+## Dashboard-First Actions
+
+| Step | Result | Evidence |
+|---|---|---|
+| Create dashboard draft | Done | Visible dashboard draft `draft-1779442977969-w2vsy4` created from `PACKAGE_3_SYMPHONY_TASK_DRAFT_PAYLOAD.json` |
+| Create Linear issue | Done | Dashboard attached Linear issue ARA-9 |
+| Prepare handoff | Done | Dashboard promoted the draft to handoff `handoff-1779443555192-bnpws7` |
+| Stage Jules manifest | Done | Dashboard staged `.jules/runs/symphony-handoff-1779443555192-bnpws7/manifest.json` |
+| Launch Jules | Done | Dashboard launched Jules session `2823658242418460192` |
+| Refresh Jules status | Done | Dashboard reported Jules state `QUEUED` and no PR captured yet |
+
+## Current Boundary
+
+- Jules state: `QUEUED`
+- PR URL: none captured yet
+- Next proof: refresh Jules status through the dashboard until Symphony either
+  captures a PR URL or records why no PR exists yet.
+
+## Dashboard UX Notes
+
+- The task navigator correctly listed Package 3 after the dashboard reload.
+- The Package 3 draft and handoff controls were inside the collapsed
+  `Task Intake And Records` drawer after several renders.
+- The agent reopened that drawer and clicked the visible card buttons rather
+  than posting to hidden endpoints.
+- The top current-boundary `Refresh Jules Status` button correctly targeted
+  `handoff-1779443555192-bnpws7` once the session existed.

--- a/docs/tasks/spells/SPELL_PHASE_1_TASK_TRACKER.md
+++ b/docs/tasks/spells/SPELL_PHASE_1_TASK_TRACKER.md
@@ -54,6 +54,16 @@ Statuses:
   `https://github.com/Gambitnl/Aralia/pull/938`
 - Package 3 handoff packet PR:
   `https://github.com/Gambitnl/Aralia/pull/939`
+- Symphony worktree Git-gate repair PR:
+  `https://github.com/Gambitnl/Aralia/pull/940`
+- Symphony scoped Git-disposition repair PR:
+  `https://github.com/Gambitnl/Aralia/pull/941`
+- Package 3 dashboard draft: `draft-1779442977969-w2vsy4`
+- Package 3 Linear issue:
+  `https://linear.app/aralia/issue/ARA-9/spell-phase-1-package-3-spellbook-and-character-creator-visibility`
+- Package 3 Symphony handoff: `handoff-1779443555192-bnpws7`
+- Package 3 Jules session:
+  `https://jules.google.com/session/2823658242418460192`
 
 ## Active Package Queue
 
@@ -64,7 +74,7 @@ Statuses:
 | P2 | done | Jules implementation, Codex foreman review | Premade level-1 party gear, combat readiness, and caster spellbook legality | `PACKAGE_2_PREMADE_PARTY_GEAR_JULES_TASK.md`, `PACKAGE_2_PREMADE_PARTY_GEAR_JULES_PROMPT.md`, `PACKAGE_2_DISPATCH_READINESS_CHECKLIST.md`, `PACKAGE_2_SYMPHONY_HANDOFF_RECEIPT.md`, `PACKAGE_2_PR_DEPLOYMENT_LOCAL_SYNC_RECEIPT.md` | PR #935 merged on 2026-05-22 after PR #937 repaired the review workflow, the PR branch was updated with current `master`, GitHub CI reran clean, and post-merge local gate checks passed on the closeout branch |
 | P2D | done | Codex foreman | Dashboard-first hardening for Package 2 handoff monitoring | `PACKAGE_2_SYMPHONY_HANDOFF_RECEIPT.md`; Decisions 26-42; PR #936; PR #937 | Dashboard-first Package 2 blockers exposed useful repairs: safe PR refresh buttons, Scout/Core glob handling, visible operator decision buttons, setup-repair lane routing, global PR boundary routing, Git Safety visibility, current-boundary action buttons, and first-viewport focus strip; Stitch MCP server entry exists but still needs authentication/restart before Stitch-generated redesigns can be used |
 | P2R | done | Codex foreman local-careful | Workflow-config repair lane for PR #935 failed `review / review` automation | local draft `draft-1779410025252-nnowpt` (`Setup repair for ARA-7`); Decisions 38, 40, 41; PR #937 | PR #937 merged, PR #935 branch was updated against current `master`, rerun CI passed, and PR #935 then merged |
-| P3 | active | Jules preferred after dashboard draft | Character creator spell selection and character sheet spellbook visibility | `PACKAGE_3_SPELLBOOK_CREATOR_VISIBILITY_JULES_TASK.md`, `PACKAGE_3_SPELLBOOK_CREATOR_VISIBILITY_JULES_PROMPT.md`, `PACKAGE_3_DISPATCH_READINESS_CHECKLIST.md`, `PACKAGE_3_SYMPHONY_TASK_DRAFT_PAYLOAD.json`, `PACKAGE_3_ATLAS_GATE_CHECKPOINT_RECEIPT.md`, `PACKAGE_3_VISUAL_PROOF_RECEIPT.md` | Package 3 task packet landed in PR #939; Symphony worktree-branch Git gate repair landed in PR #940; dashboard-first draft creation is the next visible action |
+| P3 | waiting | Jules implementation, Codex foreman monitoring | Character creator spell selection and character sheet spellbook visibility | `PACKAGE_3_SPELLBOOK_CREATOR_VISIBILITY_JULES_TASK.md`, `PACKAGE_3_SPELLBOOK_CREATOR_VISIBILITY_JULES_PROMPT.md`, `PACKAGE_3_DISPATCH_READINESS_CHECKLIST.md`, `PACKAGE_3_SYMPHONY_TASK_DRAFT_PAYLOAD.json`, `PACKAGE_3_SYMPHONY_HANDOFF_RECEIPT.md`, `PACKAGE_3_ATLAS_GATE_CHECKPOINT_RECEIPT.md`, `PACKAGE_3_VISUAL_PROOF_RECEIPT.md` | Package 3 dashboard draft `draft-1779442977969-w2vsy4`, Linear issue ARA-9, handoff `handoff-1779443555192-bnpws7`, and Jules session `2823658242418460192` were created through the visible dashboard; Jules is queued and no PR is captured yet |
 | P4 | not_started | Jules preferred after P3 | Combat simulator deterministic spell pilot | create `PACKAGE_4_*` docs after P3 | Waiting on P2/P3 |
 | P5 | not_started | Jules preferred after P4 | AI arbitration pilot for open-ended spells | create `PACKAGE_5_*` docs after deterministic pilot | Waiting on P4 |
 | P6 | not_started | Jules preferred after pilots | First mechanics bucket closure for levels 0-3 | create bucket-specific docs from current mechanics-discovery evidence | Waiting on pilot evidence |
@@ -115,7 +125,8 @@ package queue or a linked detailed task file.
 | G24 | active | Package 3 planning | Current character creator assembly may place the full class spell list in `knownSpells` while selected level 1 spells become `preparedSpells` | This may be intentional spell availability modeling, but it can make the UI look like every class spell belongs to the character if labels are unclear | Package 3 task requires Jules to preserve or repair the distinction and document the resulting known/prepared semantics |
 | G25 | active | Package 3 planning | Spellbook and spell creator surfaces need rendered proof, not just source edits | Visual verification belongs in Package 3; Package 2 deliberately did not claim this proof | `PACKAGE_3_VISUAL_PROOF_RECEIPT.md` |
 | G26 | active | Package 3 dashboard Git gate | The dashboard Git sync plan suggested pushing/pulling local `master` even though local-only `master` commits are unrelated racial-mechanics work and the active Package 3 docs are on a package branch | This is a Symphony workflow-guidance gap exposed by dashboard-first use; the agent recorded dispositions visibly, chose a non-destructive branch publication path, and landed a regression-tested Symphony fix so a clean worktree branch at `origin/master` can pass the gate without touching local `master` | Decisions 45 and 46; PR #940 merged as `ca35cf61fdc02f19e561ad1e4aff758548155ff6`; next proof is successful visible Package 3 dashboard draft creation from the repaired branch |
-| G27 | active | Package 3 dashboard Git gate follow-up | After PR #940, the dashboard correctly compared the current branch to `origin/master`, but reused an older `keep_local` disposition for unrelated local `master` commits and under-described the needed current-branch merge step as a push | This is a Symphony dashboard state-scoping defect; stale operator decisions must not carry across unrelated Git evidence | Decision 48; `conductor/symphony/src/task-intake.ts`; `conductor/symphony/scripts/verify-git-preflight-blockers.mjs`; next proof is PR/check/merge of the scoped-disposition repair, then visible Package 3 draft creation |
+| G27 | done | Package 3 dashboard Git gate follow-up | After PR #940, the dashboard correctly compared the current branch to `origin/master`, but reused an older `keep_local` disposition for unrelated local `master` commits and under-described the needed current-branch merge step as a push | This is a Symphony dashboard state-scoping defect; stale operator decisions must not carry across unrelated Git evidence | Decision 48; PR #941 merged as `3647c87d35d42dbe937e971493e12dfd16d69f9a`; the restarted dashboard Git gate reported ready on `codex/spell-phase1-package3-dashboard-flow` |
+| G28 | active | Package 3 dashboard draft/handoff launch | The dashboard task navigator showed Package 3, but the actual draft and handoff controls lived inside the collapsed `Task Intake And Records` drawer after each render; the operator had to reopen the drawer after promote/stage/launch before the next per-card button was reachable | This is a Symphony dashboard UX affordance gap, not a Package 3 spell implementation blocker; the current-boundary button did work for later Jules status refreshes | Decision 49; continue with current-boundary controls when available, and consider opening the relevant details group automatically when the selected task boundary belongs there |
 
 ## Detailed Task File Index
 
@@ -130,10 +141,11 @@ package queue or a linked detailed task file.
 | `PACKAGE_2_PR_DEPLOYMENT_LOCAL_SYNC_RECEIPT.md` | Package 2 PR/deployment/local-sync target | done for Package 2 |
 | `SPELL_PHASE_1_ARTIFACT_LIFECYCLE_POLICY.md` | Retain/archive/delete policy for package artifacts | active |
 | `PACKAGE_2_SYMPHONY_HANDOFF_RECEIPT.md` | Clean-base Package 2 draft, Linear issue, handoff, manifest, Jules launch, PR #935, and scoped verification receipt | done for Package 2 |
-| `PACKAGE_3_SPELLBOOK_CREATOR_VISIBILITY_JULES_TASK.md` | Package 3 scope and acceptance criteria | active draft |
-| `PACKAGE_3_SPELLBOOK_CREATOR_VISIBILITY_JULES_PROMPT.md` | Exact Jules prompt for Package 3 | prompt-ready, not dispatched |
-| `PACKAGE_3_DISPATCH_READINESS_CHECKLIST.md` | Handoff guard for Package 3 | active |
-| `PACKAGE_3_SYMPHONY_TASK_DRAFT_PAYLOAD.json` | Dashboard draft payload for Package 3 | draft-ready |
+| `PACKAGE_3_SPELLBOOK_CREATOR_VISIBILITY_JULES_TASK.md` | Package 3 scope and acceptance criteria | dispatched to Jules; waiting for PR |
+| `PACKAGE_3_SPELLBOOK_CREATOR_VISIBILITY_JULES_PROMPT.md` | Exact Jules prompt for Package 3 | dispatched to Jules; waiting for PR |
+| `PACKAGE_3_DISPATCH_READINESS_CHECKLIST.md` | Handoff guard for Package 3 | active; launched to Jules and waiting for PR |
+| `PACKAGE_3_SYMPHONY_HANDOFF_RECEIPT.md` | Package 3 dashboard draft, Linear issue, handoff, manifest, Jules launch, and queued status receipt | active; waiting for Jules PR |
+| `PACKAGE_3_SYMPHONY_TASK_DRAFT_PAYLOAD.json` | Dashboard draft payload for Package 3 | used for dashboard draft `draft-1779442977969-w2vsy4` |
 | `PACKAGE_3_ATLAS_GATE_CHECKPOINT_RECEIPT.md` | Package 3 Atlas/gate proof target | pending implementation |
 | `PACKAGE_3_VISUAL_PROOF_RECEIPT.md` | Package 3 rendered/test visual proof target | pending implementation |
 


### PR DESCRIPTION
## Summary
- record Package 3 dashboard draft, Linear issue, handoff, manifest, and Jules session ids
- add Package 3 Symphony handoff receipt
- update the assumed-approval decision report with the dashboard-first dispatch decision

## Verification
- node conductor/symphony/scripts/verify-spell-phase1-assumed-approval-decision-report.mjs
- npm run verify:jules-contract from conductor/symphony
- git diff --check

Jules session 2823658242418460192 is queued; no Package 3 PR is captured yet.