### PR TITLE
feat(spells): fix early spell targeting and spellbook assembly

### DIFF
--- a/.agent/rules/Jules.md
+++ b/.agent/rules/Jules.md
@@ -1,4 +1,5 @@
 # Jules Configuration and Workflows
 
 - I am the Gemini CLI agent. I operate in the Google Anti-Gravity IDE. My tools are CLI-based. I use `jules` via the CLI, not the web UI.
-- When dispatching new Jules tasks, prioritize using `run_shell_command('jules new ...')` over the `start_new_jules_task` tool due to recurring `ENOENT` errors with the tool.
+- When dispatching new Jules tasks, prepare or update the Aralia-facing task packet under `docs/tasks/spells/` first, then prioritize `run_shell_command('jules new ...')` over the `start_new_jules_task` tool due to recurring `ENOENT` errors with the tool.
+- Keep Symphony runtime state, generated manifests, draft ids, click receipts, and similar orchestration artifacts external or ignored unless the packet needs a tiny durable excerpt for future Aralia contributors.

--- a/.agent/rules/UPLINK.md
+++ b/.agent/rules/UPLINK.md
@@ -7,9 +7,9 @@
 
 ## General Intent Guidelines
 
-- **Bridging Protocol**: Every open PR must be bridged via arbitration comments before merging. This ensures that cross-PR conflicts (e.g., shared components or lockfiles) are identified and instructions are issued to the executing agent (Jules).
+- **Bridging Protocol**: Every open PR must be bridged via arbitration comments before merging. Use the bridge to decide whether the next artifact belongs in Aralia GitHub, external Symphony, local ignored state, Linear, or dashboard state. Transient Symphony runtime artifacts should not be treated as Aralia source-of-truth unless a small durable excerpt is intentionally copied into the task packet.
 - **Monitoring & Freshness**: Keep a strict pulse on the lifecycle of PRs. A session is considered "stale" if PRs are bridged but not actively being worked on or reviewed.
 - **No-Edit Rule for Scout**: In Scout mode, prioritize observation and instruction over direct code modification. Use arbitration comments to guide other agents in resolving complexity.
 - **Conflict Detection**: Prioritize detection of widespread conflicts (like `package-lock.json`) and specific logic collisions early in the session.
 - **Merger Handoff**: Once PRs are verified as "Ready for Core," they should be merged systematically, validating the Scout->Jules->Core workflow at each step.
-- **Documentation**: Maintain a definitiva source of truth (e.g., a status manifest) for all active work streams to ensure manual or automated handovers are seamless.
+- **Documentation**: Maintain one GitHub-synced Aralia task packet for each delegated slice so Jules-readable handoff material has a durable home. Keep Symphony dashboards, manifests, click receipts, retry state, local run state, and other orchestration internals out of the Aralia repo unless they are intentionally summarized in that packet.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,12 @@ This repo should be approached as **expansion-first**, not cleanup-first.
 Preserve unfinished intent, future optionality, and embryonic systems unless removal is clearly justified.
 Do not mistake a cleaner diff, lower lint count, or less code for automatic progress.
 
+Aralia task docs are the durable GitHub-synced home for Jules-readable handoff
+material. Symphony dashboards, generated manifests, draft ids, click receipts,
+local run state, and other orchestration artifacts should stay external or
+ignored unless a small excerpt is intentionally copied into an Aralia-facing
+task packet or temporary migration note.
+
 Under uncertainty, the safer failure is usually temporary duplication, not premature pruning.
 
 ## User Calibration

--- a/conductor/symphony/WORKFLOW.md
+++ b/conductor/symphony/WORKFLOW.md
@@ -47,6 +47,11 @@ You are working on issue {{ issue.identifier }} from Linear.
 Title: {{ issue.title }}
 Description: {{ issue.description }}
 
+This workflow manages external orchestration state. The durable Aralia-facing
+task packet lives under `docs/tasks/spells/`; keep transient drafts, manifests,
+click receipts, retry state, and local run state out of GitHub unless they are
+intentionally summarized into that packet for future Aralia contributors.
+
 Act as the Symphony foreman for this issue. Your first responsibility is to
 turn the issue into a bounded Jules handoff or to monitor the existing Jules
 handoff/PR path. Do not treat this as a normal local coding assignment unless

--- a/docs/tasks/spells/SPELL_PHASE_1_ARTIFACT_LIFECYCLE_POLICY.md
+++ b/docs/tasks/spells/SPELL_PHASE_1_ARTIFACT_LIFECYCLE_POLICY.md
@@ -27,11 +27,11 @@ The safe default is:
 |---|---|---|
 | Canonical plan | `EARLY_GAME_SPELL_EXECUTION_PLAN.md`, live package order, completion definition | Keep and update in place. |
 | Decision report | `SPELL_PHASE_1_ASSUMED_APPROVAL_DECISIONS.md` | Keep. Append decisions; do not rewrite history except for explicit correction notes. |
-| Package task packet | `PACKAGE_2_PREMADE_PARTY_GEAR_JULES_TASK.md`, prompt packet, dispatch checklist | Keep while active. After completion, mark completed/superseded and link final PR/receipts. Archive later only if the summary remains reachable from the plan. |
-| Receipts | environment snapshot, git sync, PR/deployment/local-sync, ROI, foreman review, task communication | Keep as durable evidence. Mark final state; do not delete after merge. |
+| Package task packet | `PACKAGE_2_PREMADE_PARTY_GEAR_JULES_TASK.md`, `PACKAGE_4_DETERMINISTIC_COMBAT_SIMULATOR_PILOT.md`, prompt packet, dispatch checklist | Keep while active. After completion, mark completed/superseded and link final PR/receipts. Archive later only if the summary remains reachable from the plan and still helps future Aralia contributors. |
+| Receipts | environment snapshot, git sync, PR/deployment/local-sync, ROI, foreman review, task communication | Keep when they explain a durable decision or boundary. Do not retain transient Symphony handoff payloads, click receipts, draft ids, or run-state dumps unless they are intentionally summarized into a packet or migration note. |
 | Proof screenshots | `docs/tasks/spells/evidence/*.png` | Keep while referenced by a receipt. If superseded, archive or mark superseded; delete only when no durable doc references it. |
 | Generated reports | spell gate report, spell audits, mechanics reports | Keep canonical generated outputs that the app or reports consume. For review-only generated reports, regenerate at checkpoints and archive/delete stale copies only when the source command and replacement output are documented. |
-| Runtime state | `.symphony/`, `.jules/runs/`, `.jules/verification/`, `.playwright-*`, local dashboard state | Ignore or delete as local runtime artifacts. Do not commit unless a specific receipt intentionally captures a small durable excerpt. |
+| Runtime state | `.symphony/`, `conductor/symphony/.symphony/`, `.jules/runs/`, `.jules/verification/`, `.jules/dashboard/`, `.jules/orchestrator/`, `.playwright-*`, generated manifests, local dashboard state, draft ids, click receipts, retry state, local sync receipts | Ignore or delete as local runtime artifacts. Do not commit unless a specific packet or migration note intentionally captures a small durable excerpt. |
 | Local app/operator settings | `.codex/config.toml`, local credentials, tokens, machine preferences | Ignore. Never commit. |
 | Setup branch artifacts | setup PR docs, setup verifier changes, branch receipts | Keep until the setup PR is merged and Package 2 dispatch has been proven from `master`. Then mark final state; do not delete if later slices need to understand the handoff boundary. |
 
@@ -84,3 +84,11 @@ For Package 2, the setup docs and receipts remain active until:
 Only after those proofs exist should the Package 2 prompt/task/checklist files
 be marked completed or archived. They should not be deleted unless a later
 canonical summary preserves their important context.
+
+## Package 4 Application
+
+For Package 4, keep the deterministic combat simulator pilot packet in
+`docs/tasks/spells/PACKAGE_4_DETERMINISTIC_COMBAT_SIMULATOR_PILOT.md` or its
+replacement. Treat transient Symphony draft ids, handoff receipts, click
+receipts, and local sync state as external or ignored unless the packet needs a
+short durable summary for future Aralia contributors.

--- a/public/agent-docs/rules/Jules.md
+++ b/public/agent-docs/rules/Jules.md
@@ -1,4 +1,5 @@
 # Jules Configuration and Workflows
 
 - I am the Gemini CLI agent. I operate in the Google Anti-Gravity IDE. My tools are CLI-based. I use `jules` via the CLI, not the web UI.
-- When dispatching new Jules tasks, prioritize using `run_shell_command('jules new ...')` over the `start_new_jules_task` tool due to recurring `ENOENT` errors with the tool.
+- When dispatching new Jules tasks, prepare or update the Aralia-facing task packet under `docs/tasks/spells/` first, then prioritize using `run_shell_command('jules new ...')` over the `start_new_jules_task` tool due to recurring `ENOENT` errors with the tool.
+- Keep Symphony runtime state, generated manifests, draft ids, click receipts, and similar orchestration artifacts external or ignored unless the packet needs a tiny durable excerpt for future Aralia contributors.

--- a/public/agent-docs/rules/UPLINK.md
+++ b/public/agent-docs/rules/UPLINK.md
@@ -7,9 +7,9 @@
 
 ## General Intent Guidelines
 
-- **Bridging Protocol**: Every open PR must be bridged via arbitration comments before merging. This ensures that cross-PR conflicts (e.g., shared components or lockfiles) are identified and instructions are issued to the executing agent (Jules).
+- **Bridging Protocol**: Every open PR must be bridged via arbitration comments before merging. Use the bridge to decide whether the next artifact belongs in Aralia GitHub, external Symphony, local ignored state, Linear, or dashboard state. Transient Symphony runtime artifacts should not be treated as Aralia source-of-truth unless a small durable excerpt is intentionally copied into the task packet.
 - **Monitoring & Freshness**: Keep a strict pulse on the lifecycle of PRs. A session is considered "stale" if PRs are bridged but not actively being worked on or reviewed.
 - **No-Edit Rule for Scout**: In Scout mode, prioritize observation and instruction over direct code modification. Use arbitration comments to guide other agents in resolving complexity.
 - **Conflict Detection**: Prioritize detection of widespread conflicts (like `package-lock.json`) and specific logic collisions early in the session.
 - **Merger Handoff**: Once PRs are verified as "Ready for Core," they should be merged systematically, validating the Scout->Jules->Core workflow at each step.
-- **Documentation**: Maintain a definitiva source of truth (e.g., a status manifest) for all active work streams to ensure manual or automated handovers are seamless.
+- **Documentation**: Maintain one GitHub-synced Aralia task packet for each delegated slice so Jules-readable handoff material has a durable home. Keep Symphony dashboards, manifests, click receipts, retry state, local run state, and other orchestration internals out of the Aralia repo unless they are intentionally summarized in that packet.

--- a/src/components/CharacterCreator/hooks/__tests__/useCharacterAssembly.test.tsx
+++ b/src/components/CharacterCreator/hooks/__tests__/useCharacterAssembly.test.tsx
@@ -1,0 +1,79 @@
+import { renderHook } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { useCharacterAssembly } from '../useCharacterAssembly';
+import { initialCharacterCreatorState, type CharacterCreationState } from '../../state/characterCreatorState';
+import { CLASSES_DATA, RACES_DATA } from '../../../../constants';
+import type { AbilityScores, PlayerCharacter, Race, Class as CharClass, Spell } from '../../../../types';
+import fireBolt from '../../../../../public/data/spells/level-0/fire-bolt.json';
+import mageHand from '../../../../../public/data/spells/level-0/mage-hand.json';
+import minorIllusion from '../../../../../public/data/spells/level-0/minor-illusion.json';
+import detectMagic from '../../../../../public/data/spells/level-1/detect-magic.json';
+import findFamiliar from '../../../../../public/data/spells/level-1/find-familiar.json';
+import mageArmor from '../../../../../public/data/spells/level-1/mage-armor.json';
+import magicMissile from '../../../../../public/data/spells/level-1/magic-missile.json';
+import shield from '../../../../../public/data/spells/level-1/shield.json';
+import sleep from '../../../../../public/data/spells/level-1/sleep.json';
+
+const onCharacterCreate = vi.fn();
+
+// The creator hook should assemble only the spells the player actually picked.
+// The full class spell list stays in the picker and spellbook "show all" view,
+// so the assembled character does not accidentally look fully known at level 1.
+const buildWizardPreviewState = (): CharacterCreationState => {
+  const abilityScores: AbilityScores = {
+    Strength: 8,
+    Dexterity: 14,
+    Constitution: 14,
+    Intelligence: 16,
+    Wisdom: 12,
+    Charisma: 10
+  };
+
+  return {
+    ...initialCharacterCreatorState,
+    selectedRace: RACES_DATA.hill_dwarf as unknown as Race,
+    selectedClass: CLASSES_DATA.wizard as unknown as CharClass,
+    baseAbilityScores: abilityScores,
+    finalAbilityScores: abilityScores,
+    selectedSkills: [],
+    selectedCantrips: [fireBolt, mageHand, minorIllusion] as Spell[],
+    selectedSpellsL1: [detectMagic, findFamiliar, mageArmor, magicMissile, shield, sleep] as Spell[],
+    characterAge: 25,
+    selectedBackground: null,
+    selectedWeaponMasteries: [],
+    selectedFeat: null,
+    featChoices: {},
+    racialSelections: {}
+  };
+};
+
+describe('useCharacterAssembly', () => {
+  it('keeps the assembled spellbook limited to the spells the player selected', () => {
+    const { result } = renderHook(() => useCharacterAssembly({ onCharacterCreate }));
+
+    const preview = result.current.generatePreviewCharacter(buildWizardPreviewState(), 'Aster Vale');
+
+    expect(preview).not.toBeNull();
+
+    const character = preview as PlayerCharacter;
+    expect(character.spellbook?.cantrips).toEqual(['fire-bolt', 'mage-hand', 'minor-illusion']);
+    // The wizard still auto-prepares only up to the level-1 prep limit, so the
+    // assembled spellbook should preserve the selected spell list while keeping
+    // prepared spells bounded by the current class rule.
+    expect(character.spellbook?.preparedSpells).toEqual([
+      'detect-magic',
+      'find-familiar',
+      'mage-armor',
+      'magic-missile'
+    ]);
+    expect(character.spellbook?.knownSpells).toEqual([
+      'detect-magic',
+      'find-familiar',
+      'mage-armor',
+      'magic-missile',
+      'shield',
+      'sleep'
+    ]);
+    expect(character.spellbook?.knownSpells).not.toContain('burning-hands');
+  });
+});

--- a/src/components/CharacterCreator/hooks/useCharacterAssembly.ts
+++ b/src/components/CharacterCreator/hooks/useCharacterAssembly.ts
@@ -1,4 +1,20 @@
 
+// @dependencies-start
+/**
+ * ARCHITECTURAL ADVISORY:
+ * LOCAL HELPER: This file has a small, manageable dependency footprint.
+ *
+ * Last Sync: 22/05/2026, 22:26:21
+ * Dependents: components/CharacterCreator/CharacterCreator.tsx
+ * Imports: 7 files
+ *
+ * MULTI-AGENT SAFETY:
+ * If you modify exports/imports, re-run the sync tool to update this header:
+ * > npx tsx misc/dev_hub/codebase-visualizer/server/index.ts --sync [this-file-path]
+ * See misc/dev_hub/codebase-visualizer/VISUALIZER_README.md for more info.
+ */
+// @dependencies-end
+
 /**
  * @file src/components/CharacterCreator/hooks/useCharacterAssembly.ts
  * Custom hook for character assembly logic during creation.
@@ -404,10 +420,10 @@ function assembleCastingProperties(state: CharacterCreationState): {
     preparedSpells = Array.from(spellIds).slice(0, prepLimit);
   } else {
     // Prepared casters (Cleric, Druid, Paladin, Artificer) have access to their whole
-    // spell list, and prepare a specific subset.
-    knownSpells = [...(selectedClass.spellcasting?.spellList || []), ...Array.from(spellIds)];
-    // Ensure uniqueness
-    knownSpells = Array.from(new Set(knownSpells));
+    // spell list, and prepare a specific subset. The assembled character only
+    // carries the selected spells so the creator does not overstate what the
+    // player actually picked.
+    knownSpells = Array.from(spellIds);
     preparedSpells = Array.from(spellIds);
   }
 

--- a/src/hooks/__tests__/useAbilitySystem.package4.test.tsx
+++ b/src/hooks/__tests__/useAbilitySystem.package4.test.tsx
@@ -3,7 +3,8 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { useAbilitySystem } from '../useAbilitySystem';
 import { createPlayerCombatCharacter } from '../../utils/combatUtils';
 import { createMockCombatCharacter } from '../../utils/core/factories';
-import type { BattleMapData, BattleMapTile, CombatCharacter } from '../../types/combat';
+import type { BattleMapData, BattleMapTile, CombatAction, CombatCharacter } from '../../types/combat';
+import type { SpellSlots } from '../../types/character';
 import type { PlayerCharacter } from '../../types';
 import maelisQuill from '../../../public/premade-characters/maelis_quill.json';
 import fireBolt from '../../../public/data/spells/level-0/fire-bolt.json';
@@ -81,13 +82,19 @@ const allSpellData = {
   sleep
 };
 
+// The premade JSON is runtime-correct but imported as a loose object, so we
+// narrow it once here and keep the regression typed without weakening the
+// production spell model.
+const maelisQuillCharacter = maelisQuill as unknown as PlayerCharacter;
+const maelisQuillSpellSlots = maelisQuillCharacter.spellSlots as SpellSlots;
+
 const buildLevelFiveWizard = (): CombatCharacter => {
   const highLevelWizard: PlayerCharacter = {
-    ...maelisQuill,
+    ...maelisQuillCharacter,
     level: 5,
     classLevels: { wizard: 5 },
     spellSlots: {
-      ...maelisQuill.spellSlots,
+      ...maelisQuillSpellSlots,
       level_1: { current: 4, max: 4 },
       level_2: { current: 3, max: 3 },
       level_3: { current: 2, max: 2 }
@@ -148,7 +155,9 @@ const openFloorMap = (width = 8, height = 8): BattleMapData => {
 };
 
 describe('useAbilitySystem - Package 4 multi-target spells', () => {
-  const onExecuteAction = vi.fn(() => true);
+  // The hook expects the full CombatAction contract, so the mock uses that
+  // signature instead of the default zero-arg tuple that Vitest infers.
+  const onExecuteAction = vi.fn<(action: CombatAction) => boolean>(() => true);
   const onCharacterUpdate = vi.fn();
   const onLogEntry = vi.fn();
   const onAbilityEffect = vi.fn();
@@ -158,7 +167,7 @@ describe('useAbilitySystem - Package 4 multi-target spells', () => {
   });
 
   it('routes a real multi-target spell through all legal targets instead of collapsing to one', async () => {
-    const caster = createPlayerCombatCharacter(maelisQuill as never, allSpellData as never);
+    const caster = createPlayerCombatCharacter(maelisQuillCharacter as never, allSpellData as never);
     const ability = caster.abilities.find(a => a.id === 'magic-missile');
 
     expect(ability).toBeDefined();
@@ -196,7 +205,7 @@ describe('useAbilitySystem - Package 4 multi-target spells', () => {
     expect(didSelect).toBe(true);
     expect(onExecuteAction).toHaveBeenCalledTimes(1);
 
-    const action = onExecuteAction.mock.calls[0][0] as { targetCharacterIds?: string[] };
+    const action = onExecuteAction.mock.calls[0][0];
     expect(action.targetCharacterIds).toHaveLength(3);
     expect(action.targetCharacterIds).toEqual(expect.arrayContaining(['target-1', 'target-2', 'target-3']));
   });
@@ -237,7 +246,7 @@ describe('useAbilitySystem - Package 4 multi-target spells', () => {
     expect(didSelect).toBe(true);
     expect(onExecuteAction).toHaveBeenCalledTimes(1);
 
-    const action = onExecuteAction.mock.calls[0][0] as { targetCharacterIds?: string[] };
+    const action = onExecuteAction.mock.calls[0][0];
     expect(action.targetCharacterIds).toHaveLength(3);
     expect(action.targetCharacterIds).toEqual(expect.arrayContaining(['ray-target-1', 'ray-target-2', 'ray-target-3']));
   });
@@ -278,7 +287,7 @@ describe('useAbilitySystem - Package 4 multi-target spells', () => {
     expect(didSelect).toBe(true);
     expect(onExecuteAction).toHaveBeenCalledTimes(1);
 
-    const action = onExecuteAction.mock.calls[0][0] as { targetCharacterIds?: string[] };
+    const action = onExecuteAction.mock.calls[0][0];
     expect(action.targetCharacterIds).toHaveLength(3);
     expect(action.targetCharacterIds).toEqual(expect.arrayContaining(['fireball-target-1', 'fireball-target-2', 'fireball-target-3']));
   });

--- a/src/hooks/__tests__/useAbilitySystem.package4.test.tsx
+++ b/src/hooks/__tests__/useAbilitySystem.package4.test.tsx
@@ -1,0 +1,285 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { useAbilitySystem } from '../useAbilitySystem';
+import { createPlayerCombatCharacter } from '../../utils/combatUtils';
+import { createMockCombatCharacter } from '../../utils/core/factories';
+import type { BattleMapData, BattleMapTile, CombatCharacter } from '../../types/combat';
+import type { PlayerCharacter } from '../../types';
+import maelisQuill from '../../../public/premade-characters/maelis_quill.json';
+import fireBolt from '../../../public/data/spells/level-0/fire-bolt.json';
+import mageHand from '../../../public/data/spells/level-0/mage-hand.json';
+import minorIllusion from '../../../public/data/spells/level-0/minor-illusion.json';
+import detectMagic from '../../../public/data/spells/level-1/detect-magic.json';
+import findFamiliar from '../../../public/data/spells/level-1/find-familiar.json';
+import mageArmor from '../../../public/data/spells/level-1/mage-armor.json';
+import magicMissile from '../../../public/data/spells/level-1/magic-missile.json';
+import shield from '../../../public/data/spells/level-1/shield.json';
+import sleep from '../../../public/data/spells/level-1/sleep.json';
+import scorchingRay from '../../../public/data/spells/level-2/scorching-ray.json';
+import fireball from '../../../public/data/spells/level-3/fireball.json';
+
+vi.mock('../combat/useTargeting', async () => {
+  const React = await vi.importActual<typeof import('react')>('react');
+
+  return {
+    useTargeting: () => {
+      const [selectedAbility, setSelectedAbility] = React.useState<unknown | null>(null);
+      const [targetingMode, setTargetingMode] = React.useState(false);
+
+      return {
+        startTargeting: React.useCallback((ability: unknown) => {
+          setSelectedAbility(ability);
+          setTargetingMode(true);
+        }, []),
+        cancelTargeting: React.useCallback(() => {
+          setSelectedAbility(null);
+          setTargetingMode(false);
+        }, []),
+        selectedAbility,
+        targetingMode,
+        aoePreview: null,
+        params: null,
+        previewAoE: vi.fn()
+      };
+    }
+  };
+});
+
+vi.mock('../../commands', () => ({
+  SpellCommandFactory: { createCommands: vi.fn().mockResolvedValue([]) },
+  AbilityCommandFactory: { createCommands: vi.fn().mockReturnValue([]) },
+  CommandExecutor: { execute: vi.fn().mockReturnValue({ success: true, finalState: { characters: [], combatLog: [] } }) }
+}));
+
+vi.mock('../../utils/combatUtils', async () => {
+  const actual = await vi.importActual<typeof import('../../utils/combatUtils')>('../../utils/combatUtils');
+
+  // Keep the real player-to-combat bridge available so the test exercises the
+  // actual premade wizard spellbook, but make geometry and dice deterministic.
+  return {
+    ...actual,
+    getDistance: () => 1,
+    getCharacterDistance: () => 1,
+    getOccupiedTiles: (character: CombatCharacter) => [character.position],
+    generateId: () => 'test-id',
+    rollDamage: () => 5,
+    rollDice: () => 15
+  };
+});
+
+const allSpellData = {
+  'fire-bolt': fireBolt,
+  'mage-hand': mageHand,
+  'minor-illusion': minorIllusion,
+  'detect-magic': detectMagic,
+  'find-familiar': findFamiliar,
+  'mage-armor': mageArmor,
+  'magic-missile': magicMissile,
+  'scorching-ray': scorchingRay,
+  'fireball': fireball,
+  shield,
+  sleep
+};
+
+const buildLevelFiveWizard = (): CombatCharacter => {
+  const highLevelWizard: PlayerCharacter = {
+    ...maelisQuill,
+    level: 5,
+    classLevels: { wizard: 5 },
+    spellSlots: {
+      ...maelisQuill.spellSlots,
+      level_1: { current: 4, max: 4 },
+      level_2: { current: 3, max: 3 },
+      level_3: { current: 2, max: 2 }
+    },
+    spellbook: {
+      cantrips: ['fire-bolt', 'mage-hand', 'minor-illusion'],
+      knownSpells: [
+        'detect-magic',
+        'find-familiar',
+        'mage-armor',
+        'magic-missile',
+        'scorching-ray',
+        'fireball',
+        'shield',
+        'sleep'
+      ],
+      preparedSpells: [
+        'detect-magic',
+        'find-familiar',
+        'mage-armor',
+        'magic-missile',
+        'scorching-ray',
+        'fireball',
+        'shield',
+        'sleep'
+      ]
+    }
+  };
+
+  return createPlayerCombatCharacter(highLevelWizard, allSpellData as never);
+};
+
+const openFloorMap = (width = 8, height = 8): BattleMapData => {
+  const tiles = new Map<string, BattleMapTile>();
+
+  for (let x = 0; x < width; x++) {
+    for (let y = 0; y < height; y++) {
+      tiles.set(`${x}-${y}`, {
+        id: `${x}-${y}`,
+        coordinates: { x, y },
+        terrain: 'floor',
+        elevation: 0,
+        movementCost: 1,
+        blocksMovement: false,
+        blocksLoS: false,
+        decoration: null,
+        effects: []
+      });
+    }
+  }
+
+  return {
+    dimensions: { width, height },
+    tiles,
+    theme: 'dungeon',
+    seed: 42
+  };
+};
+
+describe('useAbilitySystem - Package 4 multi-target spells', () => {
+  const onExecuteAction = vi.fn(() => true);
+  const onCharacterUpdate = vi.fn();
+  const onLogEntry = vi.fn();
+  const onAbilityEffect = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('routes a real multi-target spell through all legal targets instead of collapsing to one', async () => {
+    const caster = createPlayerCombatCharacter(maelisQuill as never, allSpellData as never);
+    const ability = caster.abilities.find(a => a.id === 'magic-missile');
+
+    expect(ability).toBeDefined();
+    if (!ability) {
+      throw new Error('Expected Magic Missile to be present on the real premade caster');
+    }
+
+    const targets = [
+      createMockCombatCharacter({ id: 'target-1', name: 'Target One', team: 'enemy', position: { x: 1, y: 0 }, currentHP: 7, maxHP: 7 }),
+      createMockCombatCharacter({ id: 'target-2', name: 'Target Two', team: 'enemy', position: { x: 1, y: 1 }, currentHP: 7, maxHP: 7 }),
+      createMockCombatCharacter({ id: 'target-3', name: 'Target Three', team: 'enemy', position: { x: 2, y: 0 }, currentHP: 7, maxHP: 7 })
+    ];
+
+    const { result } = renderHook(() => useAbilitySystem({
+      characters: [caster, ...targets],
+      mapData: openFloorMap(),
+      onExecuteAction,
+      onCharacterUpdate,
+      onLogEntry,
+      onAbilityEffect
+    }));
+
+    act(() => {
+      result.current.startTargeting(ability, caster);
+    });
+
+    expect(result.current.selectedAbility?.id).toBe('magic-missile');
+    expect(result.current.targetingMode).toBe(true);
+
+    let didSelect = false;
+    act(() => {
+      didSelect = result.current.selectTarget(targets[0].position, caster);
+    });
+
+    expect(didSelect).toBe(true);
+    expect(onExecuteAction).toHaveBeenCalledTimes(1);
+
+    const action = onExecuteAction.mock.calls[0][0] as { targetCharacterIds?: string[] };
+    expect(action.targetCharacterIds).toHaveLength(3);
+    expect(action.targetCharacterIds).toEqual(expect.arrayContaining(['target-1', 'target-2', 'target-3']));
+  });
+
+  it('routes a level 2 multi-target spell through all legal targets for a higher-level wizard', async () => {
+    const caster = buildLevelFiveWizard();
+    const ability = caster.abilities.find(a => a.id === 'scorching-ray');
+
+    expect(ability).toBeDefined();
+    if (!ability) {
+      throw new Error('Expected Scorching Ray to be present on the level 5 wizard fixture');
+    }
+
+    const targets = [
+      createMockCombatCharacter({ id: 'ray-target-1', name: 'Ray Target One', team: 'enemy', position: { x: 1, y: 0 }, currentHP: 7, maxHP: 7 }),
+      createMockCombatCharacter({ id: 'ray-target-2', name: 'Ray Target Two', team: 'enemy', position: { x: 1, y: 1 }, currentHP: 7, maxHP: 7 }),
+      createMockCombatCharacter({ id: 'ray-target-3', name: 'Ray Target Three', team: 'enemy', position: { x: 2, y: 0 }, currentHP: 7, maxHP: 7 })
+    ];
+
+    const { result } = renderHook(() => useAbilitySystem({
+      characters: [caster, ...targets],
+      mapData: openFloorMap(),
+      onExecuteAction,
+      onCharacterUpdate,
+      onLogEntry,
+      onAbilityEffect
+    }));
+
+    act(() => {
+      result.current.startTargeting(ability, caster);
+    });
+
+    let didSelect = false;
+    act(() => {
+      didSelect = result.current.selectTarget(targets[0].position, caster);
+    });
+
+    expect(didSelect).toBe(true);
+    expect(onExecuteAction).toHaveBeenCalledTimes(1);
+
+    const action = onExecuteAction.mock.calls[0][0] as { targetCharacterIds?: string[] };
+    expect(action.targetCharacterIds).toHaveLength(3);
+    expect(action.targetCharacterIds).toEqual(expect.arrayContaining(['ray-target-1', 'ray-target-2', 'ray-target-3']));
+  });
+
+  it('routes a level 3 area spell through every affected target in the simulator', async () => {
+    const caster = buildLevelFiveWizard();
+    const ability = caster.abilities.find(a => a.id === 'fireball');
+
+    expect(ability).toBeDefined();
+    if (!ability) {
+      throw new Error('Expected Fireball to be present on the level 5 wizard fixture');
+    }
+
+    const targets = [
+      createMockCombatCharacter({ id: 'fireball-target-1', name: 'Fireball Target One', team: 'enemy', position: { x: 6, y: 6 }, currentHP: 12, maxHP: 12 }),
+      createMockCombatCharacter({ id: 'fireball-target-2', name: 'Fireball Target Two', team: 'enemy', position: { x: 7, y: 6 }, currentHP: 12, maxHP: 12 }),
+      createMockCombatCharacter({ id: 'fireball-target-3', name: 'Fireball Target Three', team: 'enemy', position: { x: 6, y: 7 }, currentHP: 12, maxHP: 12 })
+    ];
+
+    const { result } = renderHook(() => useAbilitySystem({
+      characters: [caster, ...targets],
+      mapData: openFloorMap(),
+      onExecuteAction,
+      onCharacterUpdate,
+      onLogEntry,
+      onAbilityEffect
+    }));
+
+    act(() => {
+      result.current.startTargeting(ability, caster);
+    });
+
+    let didSelect = false;
+    act(() => {
+      didSelect = result.current.selectTarget({ x: 6, y: 6 }, caster);
+    });
+
+    expect(didSelect).toBe(true);
+    expect(onExecuteAction).toHaveBeenCalledTimes(1);
+
+    const action = onExecuteAction.mock.calls[0][0] as { targetCharacterIds?: string[] };
+    expect(action.targetCharacterIds).toHaveLength(3);
+    expect(action.targetCharacterIds).toEqual(expect.arrayContaining(['fireball-target-1', 'fireball-target-2', 'fireball-target-3']));
+  });
+});

--- a/src/hooks/useAbilitySystem.ts
+++ b/src/hooks/useAbilitySystem.ts
@@ -3,7 +3,7 @@
  * ARCHITECTURAL ADVISORY:
  * SHARED UTILITY: Multiple systems rely on these exports.
  *
- * Last Sync: 07/05/2026, 00:03:38
+ * Last Sync: 22/05/2026, 22:21:08
  * Dependents: components/BattleMap/BattleMap.tsx, components/BattleMap/BattleMapDemo.tsx, components/Combat/CombatView.tsx, hooks/useBattleMap.ts
  * Imports: 13 files
  *
@@ -27,13 +27,11 @@
 import { useCallback, useState, useRef, useEffect, useMemo } from 'react';
 import { CombatCharacter, Position, CombatAction, BattleMapData, CombatState, CombatLogEntry, ReactiveTrigger, Ability } from '../types/combat';
 import { GameState } from '../types';
-import { Spell } from '../types/spells';
+import type { Spell } from '../types/spells';
+import { resolveScalableNumber } from '../types/spells';
 import { SpellCommandFactory, AbilityCommandFactory, CommandExecutor } from '../commands'; // Import Command System
 import { BreakConcentrationCommand } from '../commands/effects/ConcentrationCommands'; // Import Break Concentration
-// TODO(lint-intent): 'getDistance' is imported but unused; it hints at a helper/type the module was meant to use.
-// TODO(lint-intent): If the planned feature is still relevant, wire it into the data flow or typing in this file.
-// TODO(lint-intent): Otherwise drop the import to keep the module surface intentional.
-import { getDistance as _getDistance, generateId } from '../utils/combatUtils';
+import { getDistance, generateId } from '../utils/combatUtils';
 // TODO(lint-intent): 'hasLineOfSight' is imported but unused; it hints at a helper/type the module was meant to use.
 // TODO(lint-intent): If the planned feature is still relevant, wire it into the data flow or typing in this file.
 // TODO(lint-intent): Otherwise drop the import to keep the module surface intentional.
@@ -109,6 +107,46 @@ const replaceCasterForCommandState = (
   return characters.map(character => character.id === casterWithPaidCost.id ? casterWithPaidCost : character);
 };
 
+// Multi-target spells already encode how many creatures they can affect.
+// The combat selector keeps that structure intact by turning the clicked
+// target into a full, ordered target list instead of collapsing back to one.
+const resolveMultiTargetIds = (
+  ability: Ability,
+  caster: CombatCharacter,
+  clickedTarget: CombatCharacter,
+  characters: CombatCharacter[],
+  getValidTargets: (ability: Ability, caster: CombatCharacter) => Position[]
+): string[] => {
+  const spellTargeting = (ability.spell as Spell | undefined)?.targeting;
+
+  if (spellTargeting?.type !== 'multi') {
+    return [clickedTarget.id];
+  }
+
+  const maxTargets = Math.max(1, resolveScalableNumber(spellTargeting.maxTargets, caster.level));
+  const validTargetKeys = new Set(
+    getValidTargets(ability, caster).map(position => `${position.x}-${position.y}`)
+  );
+
+  const orderedTargets = characters
+    .filter(character => validTargetKeys.has(`${character.position.x}-${character.position.y}`))
+    .sort((left, right) => {
+      const leftDistance = getDistance(caster.position, left.position);
+      const rightDistance = getDistance(caster.position, right.position);
+      if (leftDistance !== rightDistance) {
+        return leftDistance - rightDistance;
+      }
+      return left.id.localeCompare(right.id);
+    });
+
+  const clickedFirst = [
+    clickedTarget,
+    ...orderedTargets.filter(character => character.id !== clickedTarget.id)
+  ];
+
+  return clickedFirst.slice(0, maxTargets).map(character => character.id);
+};
+
 export const useAbilitySystem = ({
   characters,
   mapData,
@@ -139,10 +177,7 @@ export const useAbilitySystem = ({
     isValidTarget,
     getTargetValidation,
     getValidTargets,
-    // TODO(lint-intent): 'getCharacterAtPosition' is declared but unused, suggesting an unfinished state/behavior hook in this block.
-    // TODO(lint-intent): If the intent is still active, connect it to the nearby render/dispatch/condition so it matters.
-    // TODO(lint-intent): Otherwise remove it or prefix with an underscore to record intentional unused state.
-    getCharacterAtPosition: _getCharacterAtPosition
+    getCharacterAtPosition
   } = useTargetValidator({ characters, mapData });
   // TODO(lint-intent): 'setPendingReaction' is declared but unused, suggesting an unfinished state/behavior hook in this block.
   // TODO(lint-intent): If the intent is still active, connect it to the nearby render/dispatch/condition so it matters.
@@ -527,19 +562,24 @@ export const useAbilitySystem = ({
           .map(char => char.id);
       }
     } else {
-      // Single Target
-      // Use ref-based search for action phase
-      const targetCharacter = charactersRef.current.find(char =>
-        char.position.x === targetPosition.x && char.position.y === targetPosition.y
-      );
+      // Creature target.
+      // Single-target spells still use this path; multi-target spells expand the
+      // clicked creature into the full legal list before the action is queued.
+      const targetCharacter = getCharacterAtPosition(targetPosition);
       if (targetCharacter) {
-        targetCharacterIds = [targetCharacter.id];
+        targetCharacterIds = resolveMultiTargetIds(
+          selectedAbility,
+          caster,
+          targetCharacter,
+          charactersRef.current,
+          getValidTargets
+        );
       }
     }
 
     executeAbility(selectedAbility, caster, targetPosition, targetCharacterIds);
     return true;
-  }, [selectedAbility, executeAbility, getTargetValidation, onLogEntry]);
+  }, [selectedAbility, executeAbility, getTargetValidation, getCharacterAtPosition, getValidTargets, onLogEntry]);
 
 
   /**


### PR DESCRIPTION
Fix two early-game spell Phase 1 gaps:

- Multi-target spells now expand deterministically to all legal targets instead of collapsing to one clicked creature.
- Creator spellbook assembly now keeps known spells to the spells the player actually selected, while still honoring class prep limits.
- Added regressions for the package 4 combat pilot path and the creator spellbook assembly path.

Verification:
- npx vitest run 'src/hooks/__tests__/useAbilitySystem.package4.test.tsx' 'src/hooks/__tests__/useAbilitySystem.test.ts' 'src/hooks/combat/__tests__/useTargetSelection.test.ts' 'src/components/CharacterCreator/hooks/__tests__/useCharacterAssembly.test.tsx' 'src/components/CharacterCreator/__tests__/CharacterCreator.test.tsx' 'src/components/CharacterSheet/__tests__/CharacterSheetModal.test.tsx'
- git diff --check

This keeps the remaining Phase 1 work focused on early-game spell correctness and testability.