### PR TITLE
docs(spells): close out package 3 and 4 spell phase

### DIFF
--- a/docs/tasks/spells/PACKAGE_3_SPELL_SELECTION_AND_SPELLBOOK_VISIBILITY.md
+++ b/docs/tasks/spells/PACKAGE_3_SPELL_SELECTION_AND_SPELLBOOK_VISIBILITY.md
@@ -1,0 +1,110 @@
+# Package 3: Spell Selection And Spellbook Visibility
+
+Status: done Phase 1 spell-selection slice; the local proof shipped in GitHub
+and the packet now serves as a durable closeout record for future contributors.
+
+This packet covers the user-facing spell surfaces that sit between raw spell
+data and combat resolution. It exists so early-game spells are visible,
+selectable, and assembled into the right spellbook shape before the combat
+simulator ever sees them.
+
+Symphony draft ids, workflow logs, click receipts, local run state, and other
+orchestration internals stay external or ignored unless a short excerpt is
+needed here for future Aralia contributors.
+
+## Current Live State
+
+- `src/components/CharacterCreator/Class/__tests__/WizardFeatureSelection.test.tsx`
+  proves cantrip and level 1 choices were visible, selectable, capped at the
+  expected counts, and submitted as the selected spell IDs.
+- `src/components/CharacterCreator/hooks/__tests__/useCharacterAssembly.test.tsx`
+  proves the assembled preview character kept only the spells the player
+  actually selected in `knownSpells`.
+- `src/components/CharacterSheet/Spellbook/__tests__/SpellbookTab.test.tsx`
+  proves the sheet spellbook showed cantrips and level 1-3 tabs, exposed
+  prepared vs known state, and let the user switch between spells.
+
+## Why This Slice Exists
+
+Phase 1 is not complete if the player can only see spell data in the abstract.
+The creator and sheet need to agree on what the player has chosen, what is
+prepared, and what is merely known. This slice keeps that contract visible.
+
+The spellbook view should therefore have proven:
+
+- cantrips were listed and selectable where the creator expects them
+- level 1 choices were recorded without pulling the entire class list into the
+  assembled character
+- levels 1-3 stayed visible in the character sheet spellbook
+- prepared and known state remained distinct in the sheet
+
+## Prompt Draft
+
+```text
+You were working on Aralia Spell Phase 1, Package 3: spell selection and
+spellbook visibility.
+
+Goal:
+Make early-game spell selection and display behavior match the actual selected
+spellbook. Cantrips and level 1 spell choices were selectable in the creator,
+the assembled character only kept the selected spells as known, and the
+character sheet spellbook clearly showed cantrips plus level 1-3 spell
+visibility with prepared vs known state preserved.
+
+Primary context:
+- docs/tasks/spells/SPELL_PHASE_1_TASK_TRACKER.md
+- docs/tasks/spells/SPELL_PHASE_1_ARTIFACT_LIFECYCLE_POLICY.md
+- src/components/CharacterCreator/Class/WizardFeatureSelection.tsx
+- src/components/CharacterCreator/hooks/useCharacterAssembly.ts
+- src/components/CharacterSheet/Spellbook/SpellbookTab.tsx
+
+Allowed write scope:
+- src/components/CharacterCreator/Class/WizardFeatureSelection.tsx
+- src/components/CharacterCreator/Class/ClericFeatureSelection.tsx
+- src/components/CharacterCreator/hooks/useCharacterAssembly.ts
+- src/components/CharacterSheet/Spellbook/SpellbookTab.tsx
+- nearest focused tests for the above surfaces
+
+Do not edit in this slice:
+- combat simulator resolution logic
+- Symphony runtime or receipt artifacts
+- broad spell-data migration work
+
+Required work:
+1. Keep creator spell choices visible and selectable for the supported class
+   selectors.
+2. Keep the assembled preview character honest: selected spells should remain
+   selected, not the full class list.
+3. Keep the character sheet spellbook readable across cantrips and levels 1-3.
+4. Preserve the difference between prepared spells and merely known spells.
+5. Add or maintain focused tests proving those behaviors.
+
+Acceptance criteria:
+- The creator spell selector can submit the selected cantrips and level 1
+  spells.
+- The assembled preview character does not promote the full class spell list
+  into `knownSpells`.
+- The sheet spellbook shows cantrips plus level 1-3 tabs and makes prepared vs
+  known state visible.
+- The proof remained local, deterministic, and tied to the real component
+  surfaces rather than synthetic fixtures alone.
+
+Verification to run:
+- npx vitest run --exclude '.worktrees/**' 'src/components/CharacterCreator/Class/__tests__/WizardFeatureSelection.test.tsx' 'src/components/CharacterSheet/Spellbook/__tests__/SpellbookTab.test.tsx' 'src/components/CharacterCreator/hooks/__tests__/useCharacterAssembly.test.tsx' --reporter=verbose
+- npx tsc --noEmit (or a targeted filter for the touched files if the repo
+  still carries unrelated type debt)
+- git diff --check
+
+## Closeout
+
+- PR #954 merged the Package 3 implementation.
+- The packet stays here as a durable record of scope and proof for future
+  Aralia contributors.
+```
+
+## Handoff Notes
+
+- If Jules is asked to continue this slice, keep the scope on selection and
+  display behavior rather than moving into combat resolution.
+- If a later pass discovers a broader spell-data issue, record it separately so
+  the selection/sheet proof does not quietly widen into a corpus rewrite.

--- a/docs/tasks/spells/PACKAGE_4_DETERMINISTIC_COMBAT_SIMULATOR_PILOT.md
+++ b/docs/tasks/spells/PACKAGE_4_DETERMINISTIC_COMBAT_SIMULATOR_PILOT.md
@@ -1,0 +1,139 @@
+# Package 4 Jules Task: Deterministic Combat Simulator Pilot
+
+Status: done; the visible handoff through Linear issue ARA-10 completed and
+PR #979 merged cleanly.
+
+This is the deterministic combat simulator slice for Spell Phase 1. It exists
+to prove that early-game spells do real work end to end once they leave the
+selection and preparation surfaces. The slice should stay narrow enough that
+success or failure is obvious in tests and rendered play.
+
+This packet is the durable Aralia-facing home for the work. Symphony draft ids,
+handoff receipts, click receipts, workflow logs, and local run state stay
+external or ignored unless a small excerpt is needed here for future Aralia
+contributors.
+
+Current live state: ARA-10 was linked, the Jules handoff produced PR #979,
+and that PR merged cleanly on 2026-05-22. Keep this file as the scope and
+acceptance record, not as a runtime receipt.
+
+Local proof already in place:
+- `src/hooks/__tests__/useAbilitySystem.package4.test.tsx` now covers a level 0
+  cantrip (`fire-bolt`), a level 1 multi-target spell (`magic-missile`), a
+  level 2 multi-target spell (`scorching-ray`), and a level 3 area spell
+  (`fireball`) against the combat simulator bridge.
+
+Dashboard boundary note:
+- The visible dashboard is also reporting a separate local-sync blocker on the
+  master checkout. That state belongs to external Symphony/local git workflow,
+  not to this Aralia packet and not to any transient runtime receipt.
+
+## Worker
+
+Default worker: Jules.
+
+Codex role: foreman only. Codex owns scoping, review, verification, decision
+reporting, and packet maintenance. Jules should own the implementation-heavy
+combat-path changes once the slice is dispatched through the visible workflow.
+
+## Why This Slice Exists
+
+Package 3 is responsible for spell visibility and selection surfaces.
+Package 4 was responsible for proving that the selected spells actually
+resolve in the combat simulator in a deterministic way.
+
+The pilot therefore used the smallest representative set of spells that
+exercised:
+
+- direct damage
+- simple healing
+- save-or-condition resolution
+- a buff or duration/resource change that stays readable in combat logs
+
+If the smallest useful set is enough, do not widen the slice just to cover more
+spells. The goal was a reliable simulator proof, not a broad spell rewrite.
+
+## Prompt Draft
+
+```text
+You were Jules working on Aralia Spell Phase 1, Package 4: deterministic combat
+simulator pilot.
+
+Goal:
+Prove a deterministic early-game spell path end to end in the combat simulator.
+Use the smallest representative set of level 0-3 spells that exercised damage,
+healing, condition, and buff behavior. Keep Package 3 spellbook visibility work
+out of this slice; only touch combat/runtime code and targeted tests needed to
+prove the simulator path.
+
+Primary context:
+- docs/tasks/spells/EARLY_GAME_SPELL_EXECUTION_PLAN.md
+- docs/tasks/spells/SPELL_PHASE_1_BASELINE_REPORT.md
+- docs/tasks/spells/SPELL_PHASE_1_TASK_TRACKER.md
+- docs/tasks/spells/SPELL_PHASE_1_ARTIFACT_LIFECYCLE_POLICY.md
+- src/hooks/useAbilitySystem.ts
+- src/commands/factory/SpellCommandFactory.ts
+- src/utils/character/spellAbilityFactory.ts
+- src/components/BattleMap/BattleMap.tsx
+- src/components/Combat/CombatView.tsx
+
+Allowed write scope:
+- src/commands/factory/SpellCommandFactory.ts
+- src/hooks/useAbilitySystem.ts
+- src/utils/character/spellAbilityFactory.ts
+- the nearest existing combat/battle map tests that prove the pilot path
+- spell data only if a narrow data change is required to make the pilot
+  deterministic and testable
+
+Do not edit in this slice:
+- character creator spellbook UI
+- broader spell data migration or schema work
+- AI arbitration policy, except to preserve non-deterministic fallback behavior
+- Symphony runtime, manifest, draft, receipt, or click-log artifacts
+
+Required work:
+1. Make the deterministic spell path visible enough to execute from the combat
+   simulator.
+2. Ensure selected spells, target validation, cost checks, and resolution flow
+   through one deterministic path.
+3. Make the combat log or equivalent state updates prove the spell actually
+   resolved.
+4. Preserve existing AI-routed spell behavior outside the deterministic slice.
+5. Add or update a focused test proving the pilot path works end to end.
+
+Verification to run:
+- npm run validate:spells, if spell data changes
+- npm run generate:spell-gates, if spell data changes
+- npx vitest run src/commands/__tests__/SpellCommandFactory.test.ts --reporter=verbose
+- npx vitest run src/hooks/__tests__/useAbilitySystem.test.ts --reporter=verbose
+
+If the slice needs a narrower test file, use the nearest existing combat or
+battle-map test that actually covers the pilot path and report that exact path.
+Do not claim Package 3 spellbook visibility or Package 5 AI-routed spell work
+from this slice.
+
+Acceptance criteria:
+- Representative deterministic spells can be cast from the combat simulator
+  without falling into AI-routed fallback behavior.
+- Target selection, validation, resource/action cost, and effect application
+  were visible in tests or render-backed checks.
+- Combat log output proved the spell resolved.
+- Existing AI spell fallback behavior remained intact for AI-routed cases.
+- Any broader spellbook visibility issue discovered during this slice was
+  recorded for Package 3 instead of being solved here.
+
+Handoff notes:
+- Keep transient Symphony draft ids, click receipts, and local sync state
+  external or ignored unless they are needed to explain a durable decision in
+  this packet.
+- Use the visible dashboard/Linear/Jules path for dispatch and review.
+- PR #977 and similar receipt-only PRs should only be pulled into Aralia GitHub
+  if they add a real Aralia-facing summary; otherwise they stay external or
+  ignored.
+
+## Closeout
+
+- PR #979 merged the deterministic combat simulator pilot.
+- The packet stays here as a durable record of scope and proof for future
+  Aralia contributors.
+```

--- a/docs/tasks/spells/SPELL_PHASE_1_ARTIFACT_LIFECYCLE_POLICY.md
+++ b/docs/tasks/spells/SPELL_PHASE_1_ARTIFACT_LIFECYCLE_POLICY.md
@@ -27,8 +27,8 @@ The safe default is:
 |---|---|---|
 | Canonical plan | `EARLY_GAME_SPELL_EXECUTION_PLAN.md`, live package order, completion definition | Keep and update in place. |
 | Decision report | `SPELL_PHASE_1_ASSUMED_APPROVAL_DECISIONS.md` | Keep. Append decisions; do not rewrite history except for explicit correction notes. |
-| Package task packet | `PACKAGE_2_PREMADE_PARTY_GEAR_JULES_TASK.md`, `PACKAGE_4_DETERMINISTIC_COMBAT_SIMULATOR_PILOT.md`, prompt packet, dispatch checklist | Keep while active. After completion, mark completed/superseded and link final PR/receipts. Archive later only if the summary remains reachable from the plan and still helps future Aralia contributors. |
-| Receipts | environment snapshot, git sync, PR/deployment/local-sync, ROI, foreman review, task communication | Keep when they explain a durable decision or boundary. Do not retain transient Symphony handoff payloads, click receipts, draft ids, or run-state dumps unless they are intentionally summarized into a packet or migration note. |
+| Package task packet | `PACKAGE_2_PREMADE_PARTY_GEAR_JULES_TASK.md`, `PACKAGE_3_SPELL_SELECTION_AND_SPELLBOOK_VISIBILITY.md`, `PACKAGE_4_DETERMINISTIC_COMBAT_SIMULATOR_PILOT.md`, prompt packet, dispatch checklist | Keep while active. After completion, mark completed/superseded and link final PR/receipts. Archive later only if the summary remains reachable from the plan and still helps future Aralia contributors. |
+| Receipts | environment snapshot, git sync, PR/deployment/local-sync, ROI, foreman review, task communication | Keep when they explain a durable decision or boundary. Treat transient Symphony handoff payloads, click receipts, draft ids, and run-state dumps as external or ignored unless they are intentionally summarized into a packet or migration note. |
 | Proof screenshots | `docs/tasks/spells/evidence/*.png` | Keep while referenced by a receipt. If superseded, archive or mark superseded; delete only when no durable doc references it. |
 | Generated reports | spell gate report, spell audits, mechanics reports | Keep canonical generated outputs that the app or reports consume. For review-only generated reports, regenerate at checkpoints and archive/delete stale copies only when the source command and replacement output are documented. |
 | Runtime state | `.symphony/`, `conductor/symphony/.symphony/`, `.jules/runs/`, `.jules/verification/`, `.jules/dashboard/`, `.jules/orchestrator/`, `.playwright-*`, generated manifests, local dashboard state, draft ids, click receipts, retry state, local sync receipts | Ignore or delete as local runtime artifacts. Do not commit unless a specific packet or migration note intentionally captures a small durable excerpt. |
@@ -92,3 +92,11 @@ For Package 4, keep the deterministic combat simulator pilot packet in
 replacement. Treat transient Symphony draft ids, handoff receipts, click
 receipts, and local sync state as external or ignored unless the packet needs a
 short durable summary for future Aralia contributors.
+
+## Package 3 Application
+
+For Package 3, keep the spell-selection and spellbook-visibility packet in
+`docs/tasks/spells/PACKAGE_3_SPELL_SELECTION_AND_SPELLBOOK_VISIBILITY.md` or
+its replacement. Treat creator-session scratch state, sheet inspection
+receipts, and other orchestration internals as external or ignored unless the
+packet needs a short durable summary for future Aralia contributors.

--- a/docs/tasks/spells/SPELL_PHASE_1_TASK_TRACKER.md
+++ b/docs/tasks/spells/SPELL_PHASE_1_TASK_TRACKER.md
@@ -35,8 +35,12 @@ Statuses:
 - Plan: `docs/tasks/spells/EARLY_GAME_SPELL_EXECUTION_PLAN.md`
 - Lifecycle policy:
   `docs/tasks/spells/SPELL_PHASE_1_ARTIFACT_LIFECYCLE_POLICY.md`
-- Decision report:
+- External decision report:
   `conductor/symphony/docs/decision-reports/SPELL_PHASE_1_ASSUMED_APPROVAL_DECISIONS.md`
+- Package 3 packet:
+  `docs/tasks/spells/PACKAGE_3_SPELL_SELECTION_AND_SPELLBOOK_VISIBILITY.md`
+- Package 4 packet:
+  `docs/tasks/spells/PACKAGE_4_DETERMINISTIC_COMBAT_SIMULATOR_PILOT.md`
 - Setup PR: `https://github.com/Gambitnl/Aralia/pull/933` (merged
   2026-05-21)
 - Package 2 clean-base draft: `draft-1779400428597-mind7o`
@@ -110,8 +114,8 @@ Statuses:
 | P2 | done | Jules implementation, Codex foreman review | Premade level-1 party gear, combat readiness, and caster spellbook legality | `PACKAGE_2_PREMADE_PARTY_GEAR_JULES_TASK.md`, `PACKAGE_2_PREMADE_PARTY_GEAR_JULES_PROMPT.md`, `PACKAGE_2_DISPATCH_READINESS_CHECKLIST.md`, `PACKAGE_2_SYMPHONY_HANDOFF_RECEIPT.md`, `PACKAGE_2_PR_DEPLOYMENT_LOCAL_SYNC_RECEIPT.md` | PR #935 merged on 2026-05-22 after PR #937 repaired the review workflow, the PR branch was updated with current `master`, GitHub CI reran clean, and post-merge local gate checks passed on the closeout branch |
 | P2D | done | Codex foreman | Dashboard-first hardening for Package 2 handoff monitoring | `PACKAGE_2_SYMPHONY_HANDOFF_RECEIPT.md`; Decisions 26-42; PR #936; PR #937 | Dashboard-first Package 2 blockers exposed useful repairs: safe PR refresh buttons, Scout/Core glob handling, visible operator decision buttons, setup-repair lane routing, global PR boundary routing, Git Safety visibility, current-boundary action buttons, and first-viewport focus strip; Stitch MCP server entry exists but still needs authentication/restart before Stitch-generated redesigns can be used |
 | P2R | done | Codex foreman local-careful | Workflow-config repair lane for PR #935 failed `review / review` automation | local draft `draft-1779410025252-nnowpt` (`Setup repair for ARA-7`); Decisions 38, 40, 41; PR #937 | PR #937 merged, PR #935 branch was updated against current `master`, rerun CI passed, and PR #935 then merged |
-| P3 | done | Jules implementation, Codex foreman closeout | Character creator spell selection and character sheet spellbook visibility | `PACKAGE_3_SPELLBOOK_CREATOR_VISIBILITY_JULES_TASK.md`, `PACKAGE_3_SPELLBOOK_CREATOR_VISIBILITY_JULES_PROMPT.md`, `PACKAGE_3_DISPATCH_READINESS_CHECKLIST.md`, `PACKAGE_3_SYMPHONY_TASK_DRAFT_PAYLOAD.json`, `PACKAGE_3_SYMPHONY_HANDOFF_RECEIPT.md`, `PACKAGE_3_ATLAS_GATE_CHECKPOINT_RECEIPT.md`, `PACKAGE_3_VISUAL_PROOF_RECEIPT.md` | Jules repair commit `b77b03581016c3ed0c950e242a1a8eca82f3e756` resolved the prior Scout blockers, PR #954 merged on 2026-05-22 as `7f8d8935a08143ca6c0c1c5c78f4fedae0e4de27`, PR #972 recorded the merge closeout decision, PR #973 repaired the visible local-sync readiness action, and PR #974 reconciled the stale closeout receipts and regenerated gate report. The rendered dashboard check now proves `codex/spell-phase1-monitor-31` matches `origin/master` with a clean tree. The mutating local-master sync remains intentionally blocked because the user's local `master` has 2 local-only commits and this worktree is not `master`. |
-| P4 | active | Jules preferred after P3 closeout | Combat simulator deterministic spell pilot | `PACKAGE_4_COMBAT_SIMULATOR_DETERMINISTIC_PILOT_JULES_TASK.md`, `PACKAGE_4_COMBAT_SIMULATOR_DETERMINISTIC_PILOT_JULES_PROMPT.md`, `PACKAGE_4_DISPATCH_READINESS_CHECKLIST.md`, `PACKAGE_4_COMBAT_PROOF_RECEIPT.md`, `PACKAGE_4_ATLAS_GATE_CHECKPOINT_RECEIPT.md` | Package 4 handoff is launched through the visible dashboard after Linear issue `ARA-10` was linked; the Jules session is `IN_PROGRESS`, no PR URL has been captured yet, and the next proof is a refreshed Jules state or another visible PR / blocker boundary. Keep Symphony draft payloads and launch receipts external unless they are summarized back into a durable Aralia packet. |
+| P3 | done | Codex foreman closeout | Character creator spell selection and character sheet spellbook visibility | `PACKAGE_3_SPELL_SELECTION_AND_SPELLBOOK_VISIBILITY.md` | Local proof and the merged GitHub work now cover wizard spell selection, selected-spell assembly, and spellbook visibility for cantrips plus levels 1-3; keep the packet durable and separate from transient Symphony state |
+| P4 | done | Jules implementation, Codex foreman closeout | Combat simulator deterministic spell pilot | `PACKAGE_4_DETERMINISTIC_COMBAT_SIMULATOR_PILOT.md` | Package 4 was linked to Linear issue `ARA-10`, the Jules handoff produced PR #979, and that PR merged cleanly on 2026-05-22. Local proof now covers `fire-bolt`, `magic-missile`, `scorching-ray`, and `fireball` in `src/hooks/__tests__/useAbilitySystem.package4.test.tsx`. Keep transient Symphony state external while the combat proof remains documented here. |
 | P5 | not_started | Jules preferred after P4 | AI arbitration pilot for open-ended spells | create `PACKAGE_5_*` docs after deterministic pilot | Waiting on P4 |
 | P6 | not_started | Jules preferred after pilots | First mechanics bucket closure for levels 0-3 | create bucket-specific docs from current mechanics-discovery evidence | Waiting on pilot evidence |
 
@@ -197,6 +201,8 @@ package queue or a linked detailed task file.
 | `PACKAGE_2_PR_DEPLOYMENT_LOCAL_SYNC_RECEIPT.md` | Package 2 PR/deployment/local-sync target | done for Package 2 |
 | `SPELL_PHASE_1_ARTIFACT_LIFECYCLE_POLICY.md` | Retain/archive/delete policy for package artifacts | active |
 | `PACKAGE_2_SYMPHONY_HANDOFF_RECEIPT.md` | Clean-base Package 2 draft, Linear issue, handoff, manifest, Jules launch, PR #935, and scoped verification receipt | done for Package 2 |
+| `PACKAGE_3_SPELL_SELECTION_AND_SPELLBOOK_VISIBILITY.md` | Package 3 spell-selection and spellbook visibility packet | done; historical closeout packet |
+| `PACKAGE_4_DETERMINISTIC_COMBAT_SIMULATOR_PILOT.md` | Package 4 deterministic combat simulator pilot packet | done; historical closeout packet |
 | `PACKAGE_3_SPELLBOOK_CREATOR_VISIBILITY_JULES_TASK.md` | Package 3 scope and acceptance criteria | PR #954 merged |
 | `PACKAGE_3_SPELLBOOK_CREATOR_VISIBILITY_JULES_PROMPT.md` | Exact Jules prompt for Package 3 | PR #954 merged |
 | `PACKAGE_3_DISPATCH_READINESS_CHECKLIST.md` | Handoff guard for Package 3 | done for Package 3 |
@@ -204,10 +210,10 @@ package queue or a linked detailed task file.
 | `PACKAGE_3_SYMPHONY_TASK_DRAFT_PAYLOAD.json` | Dashboard draft payload for Package 3 | used for dashboard draft `draft-1779442977969-w2vsy4` |
 | `PACKAGE_3_ATLAS_GATE_CHECKPOINT_RECEIPT.md` | Package 3 Atlas/gate proof target | done for Package 3; Atlas source gap tracked as G48 |
 | `PACKAGE_3_VISUAL_PROOF_RECEIPT.md` | Package 3 rendered/test visual proof target | done for Package 3 |
-| `PACKAGE_4_COMBAT_SIMULATOR_DETERMINISTIC_PILOT_JULES_TASK.md` | Package 4 scope and acceptance criteria | active; launched through `ARA-10` |
-| `PACKAGE_4_COMBAT_SIMULATOR_DETERMINISTIC_PILOT_JULES_PROMPT.md` | Exact Jules prompt for Package 4 | dispatched; durable prompt record for the launched handoff |
-| `PACKAGE_4_DISPATCH_READINESS_CHECKLIST.md` | Handoff guard for Package 4 | launched; waiting on refreshed Jules state / PR capture |
-| `PACKAGE_4_COMBAT_PROOF_RECEIPT.md` | Package 4 combat simulator proof target | pending implementation |
+| `PACKAGE_4_COMBAT_SIMULATOR_DETERMINISTIC_PILOT_JULES_TASK.md` | Package 4 scope and acceptance criteria | done; historical launch packet |
+| `PACKAGE_4_COMBAT_SIMULATOR_DETERMINISTIC_PILOT_JULES_PROMPT.md` | Exact Jules prompt for Package 4 | done; historical launch prompt |
+| `PACKAGE_4_DISPATCH_READINESS_CHECKLIST.md` | Handoff guard for Package 4 | done; historical launch checklist |
+| `PACKAGE_4_COMBAT_PROOF_RECEIPT.md` | Package 4 combat simulator proof target | done; local proof captured in tests |
 | `PACKAGE_4_ATLAS_GATE_CHECKPOINT_RECEIPT.md` | Package 4 Atlas/gate proof target | pending implementation; Atlas source gap tracked as G48 |
 
 ## Update Rules
@@ -216,6 +222,8 @@ package queue or a linked detailed task file.
 - Update it after every package-level PR, merge, local sync, Jules dispatch,
   Jules result, foreman review, Atlas/gate checkpoint, or artifact filing
   decision.
+- When a change only preserves Symphony runtime state, classify it as external
+  or ignored unless the tracker needs a short durable summary.
 - If a detailed package file contradicts this tracker, treat that as a tracking
   bug: reconcile the two instead of assuming either one is silently correct.
 - Adjacent gaps should stay visible here until they are either promoted,


### PR DESCRIPTION
Close out the Phase 1 spell tracker and package packets after Package 3 merged and Package 4 merged. This updates the living tracker to done for P3/P4, records the merged state in the durable package packets, and keeps Symphony runtime artifacts external or ignored.