### PR TITLE
fix(symphony): expose task boundary action

### DIFF
--- a/conductor/symphony/scripts/verify-task-detail-page.mjs
+++ b/conductor/symphony/scripts/verify-task-detail-page.mjs
@@ -9,6 +9,26 @@ import { HttpServer } from '../dist/server.js';
 const BASE_URL = 'http://127.0.0.1:8199';
 const generatedAt = '2026-05-20T02:00:00.000Z';
 
+// This draft mirrors the Package 5 blocker shape: Linear already exists, so
+// the current boundary is the local handoff preparation step. The task page
+// must show that button directly, otherwise a foreman can only advance by
+// calling the hidden promote endpoint.
+const draftReadyForVisibleBoundary = {
+  id: 'draft-visible-boundary',
+  title: 'Draft visible current boundary proof',
+  body: 'Show that a ready draft can be advanced from the task page without using a hidden endpoint.',
+  expectedFiles: ['docs/tasks/spells/PACKAGE_5_AI_ARBITRATION_PILOT.md'],
+  verificationCommands: ['npm.cmd run test -- --run src/spells'],
+  executor: 'jules',
+  status: 'ready_for_handoff',
+  linearIssueId: 'lin-visible-boundary',
+  linearIssueIdentifier: 'ARA-11',
+  linearIssueUrl: 'https://linear.app/aralia/issue/ARA-11/visible-boundary',
+  linearIssueCreatedAt: generatedAt,
+  createdAt: generatedAt,
+  updatedAt: generatedAt,
+};
+
 const logger = {
   child() {
     return logger;
@@ -43,7 +63,7 @@ const server = new HttpServer(8199, orchestrator, logger);
 server.taskIntake = {
   async snapshot() {
     return {
-      drafts: [],
+      drafts: [draftReadyForVisibleBoundary],
       handoffs: [{
         id: 'handoff-detail-page',
         draftId: 'draft-detail-page',
@@ -424,6 +444,14 @@ try {
   assert.match(page.body, /Deployment Readiness/);
   assert.match(page.body, /Local Sync Readiness/);
   assert.match(page.body, /Mutates external systems<\/dt><dd>No/);
+
+  const draftPage = await getText(`${BASE_URL}/tasks/draft-visible-boundary`);
+  assert.match(draftPage.body, /Draft visible current boundary proof/);
+  assert.match(draftPage.body, /Current Boundary/);
+  assert.match(draftPage.body, /Prepare Handoff/);
+  assert.match(draftPage.body, /data-guarded-safe-endpoint="http:\/\/127\.0\.0\.1:8199\/api\/v1\/task-drafts\/draft-visible-boundary\/promote"/);
+  assert.match(draftPage.body, />Prepare Handoff<\/button>/);
+  assert.match(draftPage.body, /Runs the current Symphony boundary from this visible task page/);
 
   const missing = await getText(`${BASE_URL}/tasks/does-not-exist`, 404);
   assert.match(missing.body, /Task not found/);

--- a/conductor/symphony/src/server.ts
+++ b/conductor/symphony/src/server.ts
@@ -1543,6 +1543,7 @@ export class HttpServer {
           <div><dt>Mutates external systems</dt><dd>${detail.mutatesExternalSystems === true ? 'Yes' : 'No'}</dd></div>
           <div><dt>Mutates local files</dt><dd>${detail.mutatesLocalFiles === true ? 'Yes' : 'No'}</dd></div>
         </dl>
+        ${this.renderTaskPageCurrentBoundaryAction(detail, currentBoundary)}
         ${externalLinks ? `<nav class="task-page-links" aria-label="Task links">${externalLinks}</nav>` : ''}
       </article>
 
@@ -1787,8 +1788,10 @@ export class HttpServer {
         if (status) status.textContent = 'Operator answer failed: ' + (error?.message || error);
       }
     });
-    // Safe endpoint buttons let the task page refresh Symphony-owned evidence
-    // without asking the operator to copy a raw POST URL into another tool.
+    // Guarded endpoint buttons let the task page advance Symphony-owned
+    // boundaries without asking the operator to copy a raw POST URL into
+    // another tool. The visible button is still the decision point: the handler
+    // only runs after a human or browser-following agent clicks the page.
     const safeEndpointButtons = Array.from(document.querySelectorAll('[data-guarded-safe-endpoint]'));
     safeEndpointButtons.forEach(button => {
       button.addEventListener('click', async () => {
@@ -1810,7 +1813,7 @@ export class HttpServer {
           window.location.reload();
         } catch (error) {
           button.disabled = false;
-          if (statusNode) statusNode.textContent = 'Guarded refresh failed: ' + (error?.message || error);
+          if (statusNode) statusNode.textContent = 'Guarded action failed: ' + (error?.message || error);
         }
       });
     });
@@ -1847,6 +1850,33 @@ export class HttpServer {
   </script>
 </body>
 </html>`;
+  }
+
+  private renderTaskPageCurrentBoundaryAction(
+    detail: Record<string, unknown>,
+    currentBoundary: Record<string, unknown>,
+  ): string {
+    const endpoint = this.stringFromUnknown(currentBoundary.endpoint);
+    const method = (this.stringFromUnknown(currentBoundary.method) ?? 'POST').toUpperCase();
+    if (!endpoint || method !== 'POST' || detail.needsHumanInput === true) {
+      return '';
+    }
+
+    const label = this.stringFromUnknown(currentBoundary.label) ?? 'Run Current Boundary';
+
+    // The standalone task page must expose the same next action that the detail
+    // packet reports. Without this button, the operator can see the boundary but
+    // cannot advance it through the dashboard-first workflow, which pushes
+    // agents toward hidden endpoints instead of visible review.
+    return `<div class="task-page-current-action">
+      <ul class="task-page-actions">
+        <li>
+          <button type="button" class="primary-action compact-action" data-guarded-safe-endpoint="${this.escapeHtml(endpoint)}" data-guarded-safe-method="${this.escapeHtml(method)}">${this.escapeHtml(label)}</button>
+          <p class="usage-summary" data-guarded-safe-status></p>
+        </li>
+      </ul>
+      <p class="usage-summary">Runs the current Symphony boundary from this visible task page. Review the mutation flags above before clicking.</p>
+    </div>`;
   }
 
   private renderTaskPageGuardedActions(detail: Record<string, unknown>): string {


### PR DESCRIPTION
## Summary
- add a visible current-boundary action button to the standalone Symphony task page when the task detail packet reports a POST boundary endpoint
- reuse the guarded visible button handler instead of forcing operators/agents toward hidden endpoints
- add a Package 5-shaped task-page verifier fixture for a ready draft with Linear already linked

## Verification
- npm run build
- node scripts/verify-task-detail-page.mjs
- node scripts/verify-clean-handoff-pass-path.mjs

## Artifact boundary
This is a Symphony workflow-defect repair required to unblock the dashboard-first flow. It is not Aralia spell implementation content and should move with Symphony when Symphony is separated from the Aralia repo.