### PR TITLE
fix(symphony): keep boundary action form-backed

### DIFF
--- a/conductor/symphony/scripts/verify-task-detail-page.mjs
+++ b/conductor/symphony/scripts/verify-task-detail-page.mjs
@@ -449,8 +449,9 @@ try {
   assert.match(draftPage.body, /Draft visible current boundary proof/);
   assert.match(draftPage.body, /Current Boundary/);
   assert.match(draftPage.body, /Prepare Handoff/);
+  assert.match(draftPage.body, /<form method="post" action="http:\/\/127\.0\.0\.1:8199\/api\/v1\/task-drafts\/draft-visible-boundary\/promote">/);
   assert.match(draftPage.body, /data-guarded-safe-endpoint="http:\/\/127\.0\.0\.1:8199\/api\/v1\/task-drafts\/draft-visible-boundary\/promote"/);
-  assert.match(draftPage.body, />Prepare Handoff<\/button>/);
+  assert.match(draftPage.body, /type="submit"[^>]+>Prepare Handoff<\/button>/);
   assert.match(draftPage.body, /Runs the current Symphony boundary from this visible task page/);
 
   const missing = await getText(`${BASE_URL}/tasks/does-not-exist`, 404);

--- a/conductor/symphony/src/server.ts
+++ b/conductor/symphony/src/server.ts
@@ -1794,7 +1794,8 @@ export class HttpServer {
     // only runs after a human or browser-following agent clicks the page.
     const safeEndpointButtons = Array.from(document.querySelectorAll('[data-guarded-safe-endpoint]'));
     safeEndpointButtons.forEach(button => {
-      button.addEventListener('click', async () => {
+      button.addEventListener('click', async event => {
+        event.preventDefault();
         const endpoint = button.dataset.guardedSafeEndpoint;
         const method = button.dataset.guardedSafeMethod || 'POST';
         const statusNode = button.closest('li')?.querySelector('[data-guarded-safe-status]');
@@ -1867,11 +1868,15 @@ export class HttpServer {
     // The standalone task page must expose the same next action that the detail
     // packet reports. Without this button, the operator can see the boundary but
     // cannot advance it through the dashboard-first workflow, which pushes
-    // agents toward hidden endpoints instead of visible review.
+    // agents toward hidden endpoints instead of visible review. The form keeps
+    // the action usable even if the dashboard script fails to attach its nicer
+    // reload handler, so the visible page remains the source of the click.
     return `<div class="task-page-current-action">
       <ul class="task-page-actions">
         <li>
-          <button type="button" class="primary-action compact-action" data-guarded-safe-endpoint="${this.escapeHtml(endpoint)}" data-guarded-safe-method="${this.escapeHtml(method)}">${this.escapeHtml(label)}</button>
+          <form method="post" action="${this.escapeHtml(endpoint)}">
+            <button type="submit" class="primary-action compact-action" data-guarded-safe-endpoint="${this.escapeHtml(endpoint)}" data-guarded-safe-method="${this.escapeHtml(method)}">${this.escapeHtml(label)}</button>
+          </form>
           <p class="usage-summary" data-guarded-safe-status></p>
         </li>
       </ul>


### PR DESCRIPTION
## Summary
- make the visible task current-boundary action a normal POST form so the button remains usable even if the dashboard script does not attach
- keep the guarded script path as the preferred enhanced behavior and prevent duplicate native submit when it does run
- tighten the task-page verifier to assert the form-backed fallback exists

## Verification
- npm run build
- node scripts/verify-task-detail-page.mjs
- node scripts/verify-clean-handoff-pass-path.mjs

## Artifact boundary
Second dashboard workflow-defect repair for Package 5 handoff. This still belongs with Symphony when Symphony is moved out of Aralia; it is not spell implementation content.