### PR TITLE
docs(spells): record package 6 Jules dispatch

### DIFF
--- a/conductor/symphony/docs/decision-reports/SPELL_PHASE_1_ASSUMED_APPROVAL_DECISIONS.md
+++ b/conductor/symphony/docs/decision-reports/SPELL_PHASE_1_ASSUMED_APPROVAL_DECISIONS.md
@@ -3851,3 +3851,41 @@ Copy this block for each decision.
 - Next expected proof: Build the dashboard, publish the repair, verify the
   current-boundary `Create Linear Issue` button appears, and continue the
   Package 6 dashboard handoff.
+
+### Decision 91: Dispatch Package 6 To Jules Through The Visible Dashboard Flow
+
+- Date/time: 2026-05-24 20:15 +02:00
+- Phase: `package_6_dashboard_dispatch`
+- Active slice: Move the Package 6 `choice_or_mode` packet from visible draft
+  creation into a live Jules implementation session.
+- Decision point: After PRs #994 and #995 repaired the dashboard intake
+  affordances, the dashboard showed a clean GitHub sync gate and exposed
+  visible controls for Linear issue creation, draft promotion, manifest staging,
+  Jules launch, and session refresh.
+- Options considered:
+  - Pause after proving the dashboard buttons work.
+  - Dispatch Package 6 through the visible Symphony flow using the user's
+    pre-approved external-write and local-state decisions.
+  - Skip Symphony and start Jules separately.
+- Decision made by agent: Continue through the dashboard-visible path: create
+  Linear issue `ARA-12`, promote draft `draft-1779591924625-7hop6v` to handoff
+  `handoff-1779592447710-27ufm6`, stage the Jules manifest, launch Jules
+  session `3811311513433217520`, and refresh once.
+- Model routing: Local Codex stayed in foreman/orchestration mode. Jules was
+  assigned the implementation-heavy Package 6 spell data/runtime/test work.
+- Rationale/evidence: The active goal asks Codex to offload as much suitable
+  implementation work as possible to Jules while using the dashboard like a
+  human. The dashboard showed GitHub synced at `0f5ffb71b3a3`, then recorded the
+  handoff lifecycle and session URL. The first post-launch refresh reported
+  Jules `QUEUED`, with no PR URL and no plan-approval prompt yet.
+- Mutation performed or skipped: Created external Linear/Jules artifacts and
+  local ignored Symphony/Jules runtime receipts through visible dashboard
+  buttons. Updated the Aralia tracker with only the durable identifiers. Skipped
+  hidden endpoints, skipped local spell implementation, and kept ignored
+  `.jules`/`.symphony` runtime state out of Git.
+- Scope guardrails: This dispatch does not approve accepting any future Jules
+  PR blindly. Codex must still review file scope, generated gate churn, checks,
+  Atlas honesty, and Package 6 acceptance criteria before merge.
+- Next expected proof: Refresh the Jules session from the dashboard until it
+  either needs plan approval, needs feedback, produces a PR, fails, or remains
+  queued long enough to justify a waiting/nudge record.

--- a/docs/tasks/spells/SPELL_PHASE_1_TASK_TRACKER.md
+++ b/docs/tasks/spells/SPELL_PHASE_1_TASK_TRACKER.md
@@ -129,6 +129,16 @@ Statuses:
   `https://github.com/Gambitnl/Aralia/pull/991`
 - Package 5 dashboard stale-boundary repair PR:
   `https://github.com/Gambitnl/Aralia/pull/992`
+- Package 6 scope packet PR:
+  `https://github.com/Gambitnl/Aralia/pull/993`
+- Package 6 dashboard intake repair PRs:
+  `https://github.com/Gambitnl/Aralia/pull/994`,
+  `https://github.com/Gambitnl/Aralia/pull/995`
+- Package 6 Linear issue:
+  `https://linear.app/aralia/issue/ARA-12/spell-phase-1-package-6-choicemode-mechanics-bucket`
+- Package 6 Symphony handoff: `handoff-1779592447710-27ufm6`
+- Package 6 Jules session:
+  `https://jules.google.com/session/3811311513433217520`
 
 ## Active Package Queue
 
@@ -142,7 +152,7 @@ Statuses:
 | P3 | done | Codex foreman closeout | Character creator spell selection and character sheet spellbook visibility | `PACKAGE_3_SPELL_SELECTION_AND_SPELLBOOK_VISIBILITY.md` | Local proof and the merged GitHub work now cover wizard spell selection, selected-spell assembly, and spellbook visibility for cantrips plus levels 1-3; keep the packet durable and separate from transient Symphony state |
 | P4 | done | Jules implementation, Codex foreman closeout | Combat simulator deterministic spell pilot | `PACKAGE_4_DETERMINISTIC_COMBAT_SIMULATOR_PILOT.md` | Package 4 was linked to Linear issue `ARA-10`, the Jules handoff produced PR #979, and that PR merged cleanly on 2026-05-22. Local proof now covers `fire-bolt`, `healing-word`, `magic-missile`, `scorching-ray`, and `fireball` in `src/hooks/__tests__/useAbilitySystem.package4.test.tsx`, plus direct HP/log command proof in `DamageCommand.test.ts` and `HealingCommand.test.ts`. Keep transient Symphony state external; the bless/status gap (`G49`) and Atlas source gap (`G48`) remain separate follow-ups. |
 | P5 | done | Jules implementation, Codex foreman review | AI arbitration pilot for open-ended spells | `PACKAGE_5_AI_ARBITRATION_PILOT.md`, `PACKAGE_5_AI_ARBITRATION_PILOT_JULES_PROMPT.md` | Package 5 dispatched through clean dashboard handoff `handoff-1779586889329-3ehcfd` and Jules session `16180069342192211468`. PR #991 merged on 2026-05-24 after Jules implemented `prestidigitation` and `suggestion` AI prompts/player input, Codex removed generated gate-report churn and an out-of-scope workflow edit, the PR body was corrected, and GitHub Build/Lint/Tests/Quality/CodeQL/Poison/Analyze checks passed. Local sync and dashboard workflow closeout remain tracked under P0/Symphony, not as unfinished spell implementation. |
-| P6 | active | Codex foreman packet, Jules preferred implementation | First mechanics bucket closure for levels 0-3: `choice_or_mode` bounded implementation slice | `PACKAGE_6_CHOICE_OR_MODE_BUCKET_JULES_TASK.md`, `PACKAGE_6_CHOICE_OR_MODE_BUCKET_JULES_PROMPT.md` | Package 4 and Package 5 pilot evidence has landed. Codex created the Jules-ready packet from current mechanics-discovery evidence on branch `codex/spell-phase1-package6-mechanics`. Next boundary is visible Symphony draft/dispatch from a clean worktree, with `G48` still preventing honest Atlas proof unless separately repaired. |
+| P6 | waiting | Jules implementation, Codex foreman monitor/review | First mechanics bucket closure for levels 0-3: `choice_or_mode` bounded implementation slice | `PACKAGE_6_CHOICE_OR_MODE_BUCKET_JULES_TASK.md`, `PACKAGE_6_CHOICE_OR_MODE_BUCKET_JULES_PROMPT.md` | Package 6 was created through the visible dashboard as draft `draft-1779591924625-7hop6v`, linked to Linear issue `ARA-12`, promoted to handoff `handoff-1779592447710-27ufm6`, staged, and launched as Jules session `3811311513433217520` on 2026-05-24. Dashboard refresh currently reports Jules `QUEUED` with no PR URL and no plan-approval prompt yet. `G48` still prevents honest Atlas proof unless separately repaired. |
 
 ## Current Setup And PR Tasks
 


### PR DESCRIPTION
## Summary
- record Package 6 Linear issue ARA-12, handoff, and Jules session identifiers in the living tracker
- add Decision 91 for the dashboard-visible dispatch choices

## Verification
- node conductor/symphony/scripts/verify-spell-phase1-assumed-approval-decision-report.mjs
- git diff --check