### PR TITLE
Reveal next package intake after handoff closeout

### DIFF
--- a/conductor/symphony/public/dashboard.js
+++ b/conductor/symphony/public/dashboard.js
@@ -1830,6 +1830,7 @@ function renderForemanConsole(parts) {
     gitSafety,
     path: parts.path,
   });
+  const taskIntakeNeedsAttention = shouldOpenTaskIntakeGroup(parts.path);
 
   return `<div class="foreman-console">
     ${renderForemanCurrentBoundary(parts.path, parts.queueNextAction, parts.taskRouting)}
@@ -1837,7 +1838,7 @@ function renderForemanConsole(parts) {
       ${renderForemanDetailGroup('Git Safety', 'Preflight, disposition, sync plan, and the global path evidence.', gitSafety, gitSafetyNeedsAttention)}
       ${renderForemanDetailGroup('Jules Lifecycle', 'Kickoff, launch/session preparation, and timed nudge receipts.', julesLifecycle)}
       ${renderForemanDetailGroup('PR Review And Local Return', 'Handoff board, Scout/Core conflict watch, PR review, and local-return context.', prAndReturn)}
-      ${renderForemanDetailGroup('Task Intake And Records', 'Draft new work, watch existing PRs, and review stored drafts/handoffs.', `${parts.taskForms}${parts.records}`)}
+      ${renderForemanDetailGroup('Task Intake And Records', 'Draft new work, watch existing PRs, and review stored drafts/handoffs.', `${parts.taskForms}${parts.records}`, taskIntakeNeedsAttention)}
     </div>
   </div>`;
 }
@@ -1856,6 +1857,15 @@ function shouldOpenGitSafetyGroup({ gitSafety, path }) {
   ].filter(Boolean).join(' ');
   const safetyText = String(gitSafety || '');
   return /GitHub sync|Check GitHub Sync|Git disposition|Sync Decision Board|Guarded Git sync plan|blocked_by_disposition/i.test(`${boundaryText} ${safetyText}`);
+}
+
+function shouldOpenTaskIntakeGroup(path) {
+  // When the old Jules handoff has fully closed, the next useful operator move
+  // is usually drafting or launching the next package. Opening this drawer by
+  // default keeps the Package 14 shortcut visible instead of hiding it behind a
+  // collapsed evidence panel while the completed Local sync receipt dominates
+  // the page.
+  return path?.status === 'complete';
 }
 
 function renderBrowserFollowAlongGuidance() {

--- a/conductor/symphony/scripts/verify-task-dashboard-navigator.mjs
+++ b/conductor/symphony/scripts/verify-task-dashboard-navigator.mjs
@@ -138,6 +138,46 @@ assert.doesNotMatch(needsInputNavigatorHtml, /Setup repair draft/);
 assert.doesNotMatch(needsInputNavigatorHtml, /Merged dashboard-started proof/);
 assert.doesNotMatch(needsInputNavigatorHtml, /Promoted draft record/);
 
+const completedPathRoot = {
+  html: '',
+  addEventListener() {},
+  set innerHTML(value) {
+    this.html = value;
+  },
+  get innerHTML() {
+    return this.html;
+  },
+  firstChild: { nodeValue: '' },
+};
+const completedPathSandbox = buildSandbox(null, completedPathRoot);
+vm.runInNewContext(executableSource, completedPathSandbox, { filename: 'dashboard.js' });
+const completedPathSnapshot = buildSnapshot();
+completedPathSnapshot.middleman_path = {
+  ...completedPathSnapshot.middleman_path,
+  status: 'complete',
+  currentBoundary: 'local_sync',
+  currentBoundaryLabel: 'Local sync',
+  summary: 'Merged PR is already present locally.',
+  nextExpectedProof: 'Next package draft or handoff receipt.',
+  foremanAction: {
+    boundary: 'local_sync',
+    boundaryLabel: 'Local sync',
+    label: 'Wait for Local sync',
+    status: 'complete',
+    safety: 'operator_only',
+    canRunNow: false,
+    method: 'NONE',
+    instruction: 'The prior handoff is complete; use task intake for the next package.',
+  },
+};
+completedPathSandbox.renderTaskIntake(completedPathSnapshot);
+
+// Completed handoff paths should reveal next-work controls. This protects the
+// dashboard-first workflow from leaving the Package 14 shortcut hidden behind a
+// collapsed drawer after the old package has already been locally reconciled.
+assert.match(completedPathRoot.innerHTML, /<details class="foreman-detail-group" open>\s*<summary>\s*<span>Task Intake And Records<\/span>/);
+assert.match(completedPathRoot.innerHTML, /Create Package 14 Draft/);
+
 const completedRoot = {
   html: '',
   addEventListener() {},


### PR DESCRIPTION
## Summary
- open the Task Intake And Records drawer automatically after the middleman path is complete
- keep the next Package 14 draft shortcut visible instead of hiding it behind stale closeout receipts
- add a verifier regression for completed handoff paths showing the Package 14 shortcut

## Verification
- node conductor\\symphony\\scripts\\verify-task-dashboard-navigator.mjs
- node conductor\\symphony\\scripts\\verify-middleman-path.mjs
- npm run build from conductor/symphony
- git diff --check