### PR TITLE
Keep package intake stable while open

### DIFF
--- a/conductor/symphony/public/dashboard.js
+++ b/conductor/symphony/public/dashboard.js
@@ -813,6 +813,7 @@ function shouldHoldTaskIntakeAutoRefresh() {
   // for a moving target, so the task panel waits for an explicit click or manual
   // refresh before replacing that button or evidence link.
   return isTaskIntakeInteractionActive()
+    || Boolean(taskIntakeRoot?.querySelector?.('[data-foreman-group="Task Intake And Records"][open]'))
     || Boolean(taskIntakeRoot?.querySelector?.('[data-current-foreman-action="true"]'));
 }
 
@@ -1994,7 +1995,7 @@ function renderForemanDetailGroup(title, summary, body, open = false) {
   // Detail groups keep the existing safety surfaces available without making
   // all of them fight for first-screen priority. The current boundary above is
   // the primary decision surface; these groups are the supporting evidence.
-  return `<details class="foreman-detail-group" ${open ? 'open' : ''}>
+  return `<details class="foreman-detail-group" data-foreman-group="${escapeAttribute(title)}" ${open ? 'open' : ''}>
     <summary>
       <span>${escapeHtml(title)}</span>
       <small>${escapeHtml(summary)}</small>

--- a/conductor/symphony/scripts/verify-task-dashboard-navigator.mjs
+++ b/conductor/symphony/scripts/verify-task-dashboard-navigator.mjs
@@ -24,6 +24,7 @@ assert.match(dashboardSource, /Check Local Sync/);
 assert.match(dashboardSource, /PACKAGE_PACKET_DRAFTS/);
 assert.match(dashboardSource, /function createPackagePacketDraft/);
 assert.match(dashboardSource, /function renderPackagePacketDraftButtons/);
+assert.match(dashboardSource, /data-foreman-group/);
 assert.match(dashboardSource, /PACKAGE_10_TARGET_FILTER_DRAFT/);
 assert.match(dashboardSource, /PACKAGE_11_STATUS_STATE_DRAFT/);
 assert.match(dashboardSource, /PACKAGE_12_CONDITIONAL_ENDING_DRAFT/);
@@ -175,7 +176,7 @@ completedPathSandbox.renderTaskIntake(completedPathSnapshot);
 // Completed handoff paths should reveal next-work controls. This protects the
 // dashboard-first workflow from leaving the Package 14 shortcut hidden behind a
 // collapsed drawer after the old package has already been locally reconciled.
-assert.match(completedPathRoot.innerHTML, /<details class="foreman-detail-group" open>\s*<summary>\s*<span>Task Intake And Records<\/span>/);
+assert.match(completedPathRoot.innerHTML, /<details class="foreman-detail-group" data-foreman-group="Task Intake And Records" open>\s*<summary>\s*<span>Task Intake And Records<\/span>/);
 assert.match(completedPathRoot.innerHTML, /Create Package 14 Draft/);
 
 const completedRoot = {


### PR DESCRIPTION
## Summary
- tag dashboard detail drawers so the open Task Intake drawer can be detected
- pause automatic task-intake repainting while that drawer is open
- keep Package 14 draft controls clickable instead of detaching during auto-refresh

## Verification
- node conductor\\symphony\\scripts\\verify-task-dashboard-navigator.mjs
- node conductor\\symphony\\scripts\\verify-middleman-path.mjs
- npm run build from conductor/symphony
- git diff --check