### PR TITLE
docs: clarify spell decision lessons resolution

### DIFF
--- a/conductor/symphony/docs/decision-reports/SPELL_PHASE_1_ASSUMED_APPROVAL_DECISIONS.md
+++ b/conductor/symphony/docs/decision-reports/SPELL_PHASE_1_ASSUMED_APPROVAL_DECISIONS.md
@@ -8,16 +8,22 @@ That made the workflow auditable, but it also made the file too large to use as
 an operator surface. The detailed history is now archived, and this file is the
 stable map for where each kind of decision information belongs.
 
+If a running Jules session still shows the old giant version of this file, treat
+that as session-base drift. Jules is reading the repository snapshot it was
+launched with; it will not automatically receive the modularized decision-report
+layout from PR #1128. Use a visible Jules message, PR feedback, branch repair, or
+replacement handoff if the running task needs the new rule.
+
 ## Where To Read
 
 | Need | File |
 |---|---|
-| Current operating lessons and repeated patterns | `SPELL_PHASE_1_DECISION_TRENDS_INDEX.md` |
-| Lesson resolution status and remaining implementation gaps | `SPELL_PHASE_1_DECISION_LESSONS_RESOLUTION.md` |
-| Exact historical decision entries, timestamps, options, and proof | `archive/SPELL_PHASE_1_ASSUMED_APPROVAL_DECISIONS_FULL_LEDGER_2026-05-25.md` |
-| Active package state and next spell work | `../../../docs/tasks/spells/SPELL_PHASE_1_TASK_TRACKER.md` |
-| Symphony workflow queue and dashboard gaps | `../tasks/SYMPHONY_OPEN_TASKS.md` |
-| Durable artifact rules | `../../../docs/tasks/spells/SPELL_PHASE_1_ARTIFACT_LIFECYCLE_POLICY.md` |
+| Current operating lessons and repeated patterns | [SPELL_PHASE_1_DECISION_TRENDS_INDEX.md](./SPELL_PHASE_1_DECISION_TRENDS_INDEX.md) |
+| Lesson resolution status and remaining implementation gaps | [SPELL_PHASE_1_DECISION_LESSONS_RESOLUTION.md](./SPELL_PHASE_1_DECISION_LESSONS_RESOLUTION.md) |
+| Exact historical decision entries, timestamps, options, and proof | [archive/SPELL_PHASE_1_ASSUMED_APPROVAL_DECISIONS_FULL_LEDGER_2026-05-25.md](./archive/SPELL_PHASE_1_ASSUMED_APPROVAL_DECISIONS_FULL_LEDGER_2026-05-25.md) |
+| Active package state and next spell work | [SPELL_PHASE_1_TASK_TRACKER.md](../../../../docs/tasks/spells/SPELL_PHASE_1_TASK_TRACKER.md) |
+| Symphony workflow queue and dashboard gaps | [SYMPHONY_OPEN_TASKS.md](../tasks/SYMPHONY_OPEN_TASKS.md) |
+| Durable artifact rules | [SPELL_PHASE_1_ARTIFACT_LIFECYCLE_POLICY.md](../../../../docs/tasks/spells/SPELL_PHASE_1_ARTIFACT_LIFECYCLE_POLICY.md) |
 
 ## What Belongs Here Now
 
@@ -70,3 +76,11 @@ If a new decision exposes a new reusable lesson, update
 `SPELL_PHASE_1_DECISION_LESSONS_RESOLUTION.md` and the owning live doc in the
 same pass. The archived ledger should not become active again unless the user
 explicitly asks for raw chronological detail.
+
+The expected maintenance path is:
+
+1. Put exact historical proof in the archive only when raw audit detail is
+   explicitly needed.
+2. Put repeated patterns in the trend index.
+3. Put each reusable lesson in the lesson-resolution matrix, with either a live
+   rule, a monitor target, or a concrete source/dashboard follow-up.

--- a/conductor/symphony/docs/decision-reports/SPELL_PHASE_1_DECISION_LESSONS_RESOLUTION.md
+++ b/conductor/symphony/docs/decision-reports/SPELL_PHASE_1_DECISION_LESSONS_RESOLUTION.md
@@ -8,38 +8,68 @@ show where each lesson is now resolved. A lesson is resolved when it has a live
 operating rule, tracker row, package-template rule, or explicit remaining gap.
 This file is not another chronological log.
 
+## How To Read This File
+
+The goal is to resolve learnings, not to prove that every source-level repair is
+already shipped. A lesson is considered resolved when future agents can tell
+what rule applies and where the remaining work belongs. The source/dashboard
+repair may still be active, but the learning should no longer be trapped inside
+the archived ledger.
+
+Use this file as the triage surface:
+
+1. `implemented` means the operating rule is live and future agents can follow
+   it now.
+2. `monitor` means the rule exists but should be rechecked in future packages.
+3. `active_gap` means the rule is known, but a source/dashboard/template repair
+   still owns the next action.
+4. `retired` means the lesson only explains history.
+
 ## Resolution States
 
 | State | Meaning |
 |---|---|
 | `implemented` | A rule or tracker/process update now tells agents what to do. |
-| `active_gap` | The lesson is understood, but source/dashboard/template work remains. |
+| `active_gap` | The lesson is understood and routed, but source/dashboard/template work remains. |
 | `monitor` | The rule exists; future packages should prove whether it holds. |
 | `retired` | The lesson is historical and no longer needs active routing attention. |
+
+## Resolution Summary
+
+The full ledger has already been pruned into an archive and two live operator
+surfaces:
+
+- repeated patterns live in `SPELL_PHASE_1_DECISION_TRENDS_INDEX.md`;
+- reusable lessons live in this matrix;
+- exact historical entries live in
+  `archive/SPELL_PHASE_1_ASSUMED_APPROVAL_DECISIONS_FULL_LEDGER_2026-05-25.md`.
+
+All extracted lessons now have an owning surface. The remaining work is source
+or dashboard follow-through, not more ledger extraction.
 
 ## Lessons
 
 | Lesson | Resolution | Owning live surface | Current rule |
 |---|---|---|---|
 | Tool approval prompts are not automatically project approval gates. | `implemented` | `SPELL_PHASE_1_ASSUMED_APPROVAL_DECISIONS.md`; `JULES_MIDDLEMAN_OPERATING_SPEC.md` | Separate environment/tool boundaries from project decisions. Record the exact external proof needed, but do not block product scope on generic tooling prompts. |
-| Durable context should be concise and Aralia-facing, not raw Symphony output. | `implemented` | `../../../docs/tasks/spells/SPELL_PHASE_1_ARTIFACT_LIFECYCLE_POLICY.md`; `../../../AGENTS.md` | Commit task packets, prompts, tracker updates, product PR links, acceptance summaries, and short blocker explanations. Keep generated manifests, click receipts, draft ids, local task-store churn, and raw Jules/Symphony runtime state ignored or external. |
+| Durable context should be concise and Aralia-facing, not raw Symphony output. | `implemented` | `../../../../docs/tasks/spells/SPELL_PHASE_1_ARTIFACT_LIFECYCLE_POLICY.md`; `../../../../AGENTS.md` | Commit task packets, prompts, tracker updates, product PR links, acceptance summaries, and short blocker explanations. Keep generated manifests, click receipts, draft ids, local task-store churn, and raw Jules/Symphony runtime state ignored or external. |
 | Jules sessions are isolated launch clones. | `implemented` | `../JULES_MIDDLEMAN_OPERATING_SPEC.md`; `../tasks/SYMPHONY_OPEN_TASKS.md` | Later local tracker edits or merged GitHub docs do not reach a running Jules session automatically. Use a visible Jules message, bounded PR feedback, PR-branch repair/rebase, or replacement handoff. |
 | Active Jules work needs visual page inspection. | `implemented` | `../JULES_MIDDLEMAN_OPERATING_SPEC.md`; `../tasks/SYMPHONY_OPEN_TASKS.md` | Dashboard/local status is only one signal. Open the visible Jules page when a task is active and record whether it is planning, waiting, working, failed, or showing PR proof. |
 | Ordinary Jules progress is not a full decision. | `implemented` | `SPELL_PHASE_1_DECISION_TRENDS_INDEX.md`; `../JULES_MIDDLEMAN_OPERATING_SPEC.md` | Queue/setup/working/verify refreshes should be compact wait rows unless the foreman must choose between materially different actions. |
-| Plan revision feedback should change the next action away from stale approval. | `active_gap` | `../tasks/SYMPHONY_OPEN_TASKS.md` | After Codex sends a bounded revision note while Jules waits for approval, the dashboard should route to refresh/wait for revised plan, not keep surfacing `Approve Jules Plan`. |
-| Package selection must come from the living tracker and execution plan. | `implemented` | `../../../docs/tasks/spells/SPELL_PHASE_1_TASK_TRACKER.md`; `../../../docs/tasks/spells/EARLY_GAME_SPELL_EXECUTION_PLAN.md` | Do not encode temporary package state into the goal. Pick the next package from tracker evidence and update the tracker before dispatch. |
-| Jules package size needs a higher minimum boundary. | `implemented` | `../JULES_MIDDLEMAN_OPERATING_SPEC.md`; `../../../docs/tasks/spells/SPELL_PHASE_1_TASK_TRACKER.md` | Jules should get coherent multi-row mechanics/schema/test batches or deliberate workflow proofs. One-file docs, stale counts, PR-body edits, raw-artifact cleanup, tracker closeout, and branch-hygiene acceptance repairs stay local. Add a concrete `Jules value: ...` line before launch. |
+| Plan revision feedback should change the next action away from stale approval. | `implemented` | `../JULES_MIDDLEMAN_OPERATING_SPEC.md`; `../tasks/SYMPHONY_OPEN_TASKS.md` | PR #1119 proved the routing repair. After Codex sends a bounded revision note while Jules waits for approval, the dashboard should route to refresh/wait for a revised plan, not keep surfacing `Approve Jules Plan`. |
+| Package selection must come from the living tracker and execution plan. | `implemented` | `../../../../docs/tasks/spells/SPELL_PHASE_1_TASK_TRACKER.md`; `../../../../docs/tasks/spells/EARLY_GAME_SPELL_EXECUTION_PLAN.md` | Do not encode temporary package state into the goal. Pick the next package from tracker evidence and update the tracker before dispatch. |
+| Jules package size needs a higher minimum boundary. | `implemented` | `../JULES_MIDDLEMAN_OPERATING_SPEC.md`; `../../../../docs/tasks/spells/SPELL_PHASE_1_TASK_TRACKER.md` | Jules should get coherent multi-row mechanics/schema/test batches or deliberate workflow proofs. One-file docs, stale counts, PR-body edits, raw-artifact cleanup, tracker closeout, and branch-hygiene acceptance repairs stay local. Add a concrete `Jules value: ...` line before launch. |
 | Plans that name out-of-scope files require rejection or justification. | `implemented` | `../JULES_MIDDLEMAN_OPERATING_SPEC.md`; package task packets | Withhold approval unless the extra file is necessary, package-local, and explicitly justified. |
 | Larger packages still need classification-first planning. | `monitor` | `../tasks/SYMPHONY_OPEN_TASKS.md`; future package packets | Require full candidate classification before implementation selection, then list `implement_now`, residual, deferred, and out-of-scope rows. |
 | Helper artifacts and workflow quota bypasses are branch noise, not product work. | `implemented` | `SPELL_PHASE_1_DECISION_TRENDS_INDEX.md`; `../tasks/SYMPHONY_OPEN_TASKS.md` | Ask Jules to remove scratch scripts/caches before PR submission. If final PR still carries helper or workflow noise, preserve accepted product files on a clean branch or reject the PR. |
 | Useful Jules work can be salvaged through bounded branch hygiene. | `implemented` | `SPELL_PHASE_1_DECISION_TRENDS_INDEX.md`; `../JULES_MIDDLEMAN_OPERATING_SPEC.md` | After at least one clear repair request, a foreman may repair the PR branch from current `origin/master` if it preserves only accepted product/test/docs and reruns focused proof. |
 | A new Jules PR head does not automatically resolve repair feedback. | `implemented` | `../tasks/SYMPHONY_OPEN_TASKS.md`; `SPELL_PHASE_1_DECISION_TRENDS_INDEX.md` | Compare the new diff with the requested repair. Green checks or a changed commit hash are not enough. |
 | One explicit `@jules` nudge is enough before choosing a different repair path. | `implemented` | `SPELL_PHASE_1_DECISION_TRENDS_INDEX.md` | If bounded repair feedback receives no useful head change, post one clear nudge. After acknowledgement or another incomplete repair, choose branch hygiene, replacement handoff, or stale filing instead of looping indefinitely. |
-| Local `COMPLETED` without PR proof is not package closeout. | `active_gap` | `../tasks/SYMPHONY_OPEN_TASKS.md` | Treat no-PR completion as `needs_browser_reconciliation` until visible Jules/GitHub proof confirms a PR, blocker, or true no-PR result. |
-| Fresh drafts must outrank stale completed handoffs in the dashboard queue. | `active_gap` | `../tasks/SYMPHONY_OPEN_TASKS.md` | Completed/local-current handoffs and closed PR feedback should remain history, but the global next action should prefer the newest ready draft when no live boundary requires operator action. |
+| Local `COMPLETED` without PR proof is not package closeout. | `implemented` | `../JULES_MIDDLEMAN_OPERATING_SPEC.md`; `../tasks/SYMPHONY_OPEN_TASKS.md` | `needs_browser_reconciliation` is now the rule: visible Jules/GitHub proof must confirm a PR, blocker, or true no-PR result before closeout. Keep monitoring future packages for stale local records. |
+| Fresh drafts must outrank stale completed handoffs in the dashboard queue. | `implemented` | `../JULES_MIDDLEMAN_OPERATING_SPEC.md`; `../tasks/SYMPHONY_OPEN_TASKS.md` | PR #1117 proved the current queue-focus repair. Completed/local-current handoffs and closed PR feedback remain history, but the global next action should prefer the newest ready draft when no live boundary requires operator action. |
 | Visible controls must remain stable while the operator interacts. | `monitor` | `../tasks/SYMPHONY_OPEN_TASKS.md`; dashboard verifier suite | Task-intake controls should not detach during interaction. Future dashboard controls should follow the open-drawer stability rule. |
 | Mutation labels need to match real external boundaries. | `active_gap` | `../tasks/SYMPHONY_OPEN_TASKS.md`; task-page safety labels | Linear creation, manifest staging, Jules launch, PR feedback, push, merge, and local sync should be labeled as real boundary changes, not harmless display refreshes. |
-| Decision evidence should be modular. | `implemented` | This file; `SPELL_PHASE_1_DECISION_TRENDS_INDEX.md`; archived full ledger | Use the short decision record as the entry point, the trend index for operator reading, the lesson matrix for reusable rules, and the archive only for exact historical audit. |
+| Decision evidence should be modular. | `implemented` | `SPELL_PHASE_1_ASSUMED_APPROVAL_DECISIONS.md`; this file; `SPELL_PHASE_1_DECISION_TRENDS_INDEX.md`; archived full ledger | PR #1128 pruned the old active ledger. Use the short decision record as the entry point, the trend index for operator reading, the lesson matrix for reusable rules, and the archive only for exact historical audit. |
 
 ## Retired Historical Lessons
 
@@ -48,16 +78,18 @@ This file is not another chronological log.
 | Package 2 setup needed the original assumed-approval decision scaffolding. | Package 2 through Package 15 proved the basic decision trail. The active need is compact routing, not a longer chronological ledger. |
 | Every phase needed a full decision entry during the test flow. | Superseded by compact wait-state logging and the lesson matrix. Full entries are now only for real forks. |
 
-## Remaining Work Queue
+## Remaining Source And Dashboard Work
 
-These are the unresolved lessons that still need source/dashboard/template work:
+These are not unextracted learnings. They are the source/dashboard/template
+repairs that still remain after the lessons were extracted from the ledger:
 
-1. Make plan-revision feedback route to refresh/wait instead of stale approval.
-2. Reconcile local Jules `COMPLETED` with visible Jules/GitHub proof before
-   calling a package complete.
-3. Keep fresh drafts ahead of stale completed handoff history in the visible
-   dashboard queue.
-4. Keep visible controls stable during interaction.
-5. Correct task-page mutation labels for external boundary actions.
-6. Add the `Jules value: ...` line to future package templates and dashboard
-   launch/approval surfaces.
+1. Replace hardcoded package shortcut entries with metadata-derived packet
+   discovery so the Package 16 shortcut drift does not repeat for Package 17.
+2. Keep visible controls stable during interaction and extend the open-drawer
+   stability rule to future dashboard controls.
+3. Correct task-page mutation labels for external boundary actions.
+4. Surface the `Jules value: ...` line in future package templates and dashboard
+   launch/approval surfaces, not only in the operating spec.
+5. Keep monitoring plan-revision routing, no-PR completion reconciliation, and
+   stale-history queue focus in future packages; the rules are implemented, but
+   the proving-ground should continue to catch regressions.

--- a/conductor/symphony/docs/decision-reports/SPELL_PHASE_1_DECISION_TRENDS_INDEX.md
+++ b/conductor/symphony/docs/decision-reports/SPELL_PHASE_1_DECISION_TRENDS_INDEX.md
@@ -22,9 +22,9 @@ lesson is implemented, still an active gap, being monitored, or retired.
 
 | File | Role |
 |---|---|
-| `SPELL_PHASE_1_ASSUMED_APPROVAL_DECISIONS.md` | Short entry point and logging policy. |
-| `SPELL_PHASE_1_DECISION_LESSONS_RESOLUTION.md` | Extracted lessons with resolution state and owning live surface. |
-| `archive/SPELL_PHASE_1_ASSUMED_APPROVAL_DECISIONS_FULL_LEDGER_2026-05-25.md` | Full chronological audit archive. |
+| [SPELL_PHASE_1_ASSUMED_APPROVAL_DECISIONS.md](./SPELL_PHASE_1_ASSUMED_APPROVAL_DECISIONS.md) | Short entry point and logging policy. |
+| [SPELL_PHASE_1_DECISION_LESSONS_RESOLUTION.md](./SPELL_PHASE_1_DECISION_LESSONS_RESOLUTION.md) | Extracted lessons with resolution state and owning live surface. |
+| [archive/SPELL_PHASE_1_ASSUMED_APPROVAL_DECISIONS_FULL_LEDGER_2026-05-25.md](./archive/SPELL_PHASE_1_ASSUMED_APPROVAL_DECISIONS_FULL_LEDGER_2026-05-25.md) | Full chronological audit archive. |
 
 ## 1. Current Trend Summary
 
@@ -41,6 +41,12 @@ mechanics. The repeated pattern is:
 The useful product work is real, but the orchestration cost is high. Future
 packages should be large enough to justify draft, Linear, handoff, Jules launch,
 plan approval, PR review, repair, merge, and tracker closeout.
+
+PR #1128 resolved the decision-file bloat itself: the chronological audit is now
+archived, the original path is only an entry point, and this file carries the
+operator-readable trends. Do not re-expand the active decision file when a
+future Jules session shows old giant content; that is session-base drift, not a
+request to revive the old ledger.
 
 ## 2. Recurring Decision Types
 
@@ -187,7 +193,7 @@ lease, and merged after focused local and GitHub verification.
 | Gap | Current evidence | Desired repair |
 |---|---|---|
 | Decision report was too large to navigate | The assumed-approval report grew past 4,000 lines and mixed audit entries with trend discovery. | Resolved by modularization: the old full ledger now lives under `archive/`, the original path is a short entry point, this trend index is the operator summary, and `SPELL_PHASE_1_DECISION_LESSONS_RESOLUTION.md` tracks extracted lessons and remaining gaps. Keep these smaller surfaces current instead of reviving the full ledger as the active log. |
-| Packet shortcuts are hardcoded | Package 11, Package 12, and Package 13 all exposed that the visible draft path lags behind new committed package packets. PR #1090 moved Package 13 shortcut rendering/click handling to a small packet registry. | Next target is metadata-derived discovery from committed packet files so a new package packet does not require another dashboard source edit. |
+| Packet shortcuts are hardcoded | Package 11, Package 12, Package 13, and Package 16 all exposed that the visible draft path lags behind new committed package packets. PR #1090 moved Package 13 shortcut rendering/click handling to a small packet registry; PR #1130 added the Package 16 shortcut after visible dashboard proof showed it was missing. | Next target is metadata-derived discovery from committed packet files so a new package packet does not require another dashboard source edit. |
 | Fresh draft can lose queue focus to stale handoff history | Package 15 proved the visible draft shortcut by creating `draft-1779771507621-vox90j`, and a visible refresh reconciled Package 14 to merged/local-current. The queue still surfaced an older unlaunched stale Package 11 handoff as the top action before the new draft's Linear boundary. After PR #1115 and Linear `ARA-24`, an older Package 10 completed/no-PR post-launch update record repeated the same focus problem before Package 15 handoff prep. A later live check showed closed Package 9 PR #1030 feedback and Package 14 completed middleman-path receipts could still hide Package 15 `Prepare Handoff`; PR #1117 repaired that path and visual proof then reached Package 15 Jules launch. | Completed/local-current handoffs, old unlaunched stale handoffs, completed/no-PR handoffs already superseded by replacement package paths, and closed-PR feedback history may stay visible as history, but the global next action should prefer the newest ready draft when no live Jules/PR boundary needs operator action. A draft linked to Linear needs its own `Prepare Handoff` stage before old manifest/session/PR/local-sync receipts can count for the current path. |
 | Merged handoff can remain the active dashboard boundary | After Package 13 and Package 14 prep merged, visual dashboard use still kept the old Package 13 handoff on the active Scout/Core review boundary because historical conflict-prone file evidence outlived the merged PR and local-current proof. | Merged PRs should complete the Scout/Core lane, local-current proof should complete the local-sync lane, and the dashboard should surface the next package draft path instead of stale review. |
 | Visible controls can still be unstable | Package 14 launch showed that even after a next-package button exists and the correct drawer is open, automatic dashboard repainting can detach the button while the operator or browser automation is trying to click it. | Keep next-action intake controls visible and stable during interaction. PR #1101 tags the open Task Intake drawer and pauses automatic repainting while it is open; future controls should follow the same stability rule. |


### PR DESCRIPTION
## Summary
- clarify the pruned Spell Phase 1 decision-report entry point and stale Jules-session behavior
- separate extracted learnings from remaining source/dashboard follow-up work
- update trend pointers for PR #1128 and Package 16 shortcut drift, with clickable doc links

## Verification
- git diff --check HEAD~1..HEAD
- pre-push sync-check passed