### PR TITLE
Add Google Gemini fallback with player-supplied credentials

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,20 @@
-# Required
+# AI narration
+# Aralia runs narrative AI on local Ollama by default. Players can supply their
+# OWN Google Gemini credential at runtime (API key or "Sign in with Google") as
+# a fallback when Ollama is unavailable — no key needs to be baked in here.
+
+# Optional: bake in a Gemini API key for the whole deployment (most setups leave
+# this unset and let each player provide their own credential at runtime).
 GEMINI_API_KEY=your_api_key_here
 
-# Optional
+# Optional: enable the "Sign in with Google" fallback path. This is a PUBLIC
+# OAuth 2.0 client ID (not a secret, not an API key) that identifies this
+# deployment to Google's consent screen. When unset, the OAuth button is hidden
+# and players use the API-key path instead.
+# VITE_GOOGLE_CLIENT_ID=your_oauth_client_id.apps.googleusercontent.com
+
+# Optional: override the OAuth scopes requested at Google sign-in.
+# VITE_GOOGLE_OAUTH_SCOPE=https://www.googleapis.com/auth/cloud-platform https://www.googleapis.com/auth/userinfo.email
+
+# Dev
 VITE_ENABLE_DEV_TOOLS=false

--- a/docs/ai/gemini-fallback.md
+++ b/docs/ai/gemini-fallback.md
@@ -1,0 +1,67 @@
+# Gemini fallback (bring-your-own credential)
+
+Aralia generates narrative text (location/wilderness descriptions, NPC replies,
+action outcomes, oracle guidance, etc.) with a **local Ollama** model by
+default. When Ollama isn't available — not installed, not running, or no model
+pulled — the player can opt in to fall back to **Google Gemini** using a
+credential **they supply themselves**.
+
+Nothing is baked into the app. No shared API key ships with Aralia. The player's
+credential lives only in their browser (localStorage) and is sent only to
+Google's API from their own machine.
+
+## Two ways for a player to authenticate
+
+1. **API key** — the player pastes their own key from
+   [Google AI Studio](https://aistudio.google.com/apikey). Always available;
+   fully self-contained.
+2. **Sign in with Google (OAuth)** — the player signs in with their own Google
+   account and Aralia receives a short-lived access token. This path is only
+   offered when the deployment has configured a public OAuth client ID (see
+   below), and requires the player's Google Cloud project to have the Generative
+   Language API enabled.
+
+Players configure this in the **Ollama Dependency** pane (shown when Ollama is
+detected as unavailable), under *"Prefer not to install Ollama? Use Google
+Gemini instead."*
+
+## How the redirect works
+
+All narrative calls funnel through `src/services/ollamaTextService.ts`. When an
+Ollama call fails (no model / unreachable), it checks
+`isGeminiFallbackReady()` — true only when the player has both opted in **and**
+supplied a usable credential — and, if ready, forwards the same prompt +
+system instruction to Gemini via `src/services/gemini/core.ts`. Consumers are
+unchanged; the redirect is transparent.
+
+Credential resolution for every Gemini-backed service is centralized in
+`src/services/aiClient.ts`, which picks (in priority order):
+
+1. the player's runtime credential (API key or OAuth token), else
+2. a build-time `GEMINI_API_KEY`, if a deployment chose to bake one in.
+
+## Deployment configuration (optional)
+
+| Env var | Purpose |
+| --- | --- |
+| `GEMINI_API_KEY` | Optional build-time key for the whole deployment. Most setups leave this unset. |
+| `VITE_GOOGLE_CLIENT_ID` | Public OAuth 2.0 client ID that enables the "Sign in with Google" button. Not a secret. When unset, only the API-key path is shown. |
+| `VITE_GOOGLE_OAUTH_SCOPE` | Override the requested OAuth scopes (defaults to `cloud-platform` + `userinfo.email`). |
+
+### Setting up the OAuth client ID
+
+1. In Google Cloud Console, create an **OAuth 2.0 Client ID** of type *Web
+   application*.
+2. Add your app's origin to **Authorized JavaScript origins**.
+3. Enable the **Generative Language API** on the project.
+4. Set `VITE_GOOGLE_CLIENT_ID` to the client ID and rebuild.
+
+## Relevant modules
+
+- `src/services/ai/aiCredentials.ts` — runtime credential store + readiness gate.
+- `src/services/ai/googleOAuth.ts` — Google Identity Services sign-in wrapper.
+- `src/services/ai/oauthGeminiClient.ts` — REST adapter that calls Gemini with a
+  bearer token (the SDK is API-key-only in the browser).
+- `src/services/aiClient.ts` — central credential resolver / shared client.
+- `src/services/ollamaTextService.ts` — Ollama→Gemini redirect on failure.
+- `src/components/ui/GeminiFallbackSettings.tsx` — the opt-in UI.

--- a/src/components/ui/GeminiFallbackSettings.tsx
+++ b/src/components/ui/GeminiFallbackSettings.tsx
@@ -1,0 +1,222 @@
+/**
+ * @file src/components/ui/GeminiFallbackSettings.tsx
+ * @component-owner Narrative Team / Core UI
+ * @status New
+ *
+ * Lets a player opt in to using Google Gemini for AI narration when local
+ * Ollama is unavailable, authenticating with THEIR OWN credential:
+ *   - a Google AI Studio API key they paste, or
+ *   - an OAuth token from signing in with their own Google account.
+ *
+ * Nothing is baked into the app; the credential is stored only in the player's
+ * browser (see src/services/ai/aiCredentials.ts). Rendered inside
+ * OllamaDependencyModal.
+ */
+
+import React, { useState } from 'react';
+import { Button } from './Button';
+import { Checkbox, Input } from './Input';
+import { useAiCredentials } from '../../hooks/useAiCredentials';
+import {
+  clearGeminiApiKey,
+  clearOAuthToken,
+  isGeminiFallbackReady,
+  setGeminiApiKey,
+  setGeminiAuthMode,
+  setGeminiFallbackEnabled,
+} from '../../services/ai/aiCredentials';
+import { isGoogleOAuthConfigured, signInWithGoogle } from '../../services/ai/googleOAuth';
+
+const API_KEY_HELP_URL = 'https://aistudio.google.com/apikey';
+
+export const GeminiFallbackSettings: React.FC = () => {
+  const creds = useAiCredentials();
+  const oauthConfigured = isGoogleOAuthConfigured();
+
+  const [apiKeyDraft, setApiKeyDraft] = useState('');
+  const [signingIn, setSigningIn] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const ready = isGeminiFallbackReady();
+  const hasStoredKey = !!creds.geminiApiKey;
+
+  const handleToggleFallback = (enabled: boolean) => {
+    setError(null);
+    setGeminiFallbackEnabled(enabled);
+  };
+
+  const handleSaveKey = () => {
+    const trimmed = apiKeyDraft.trim();
+    if (!trimmed) {
+      setError('Enter an API key first.');
+      return;
+    }
+    setError(null);
+    setGeminiApiKey(trimmed);
+    setGeminiAuthMode('apiKey');
+    setApiKeyDraft('');
+  };
+
+  const handleClearKey = () => {
+    setError(null);
+    clearGeminiApiKey();
+  };
+
+  const handleSignIn = async () => {
+    setError(null);
+    setSigningIn(true);
+    try {
+      await signInWithGoogle();
+      setGeminiAuthMode('oauth');
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Google sign-in failed.');
+    } finally {
+      setSigningIn(false);
+    }
+  };
+
+  const handleSignOut = () => {
+    setError(null);
+    clearOAuthToken();
+    setGeminiAuthMode('apiKey');
+  };
+
+  return (
+    <div
+      data-testid="gemini-fallback-settings"
+      className="bg-gray-800/50 border-l-4 border-sky-500/50 p-4 rounded space-y-4"
+    >
+      <div>
+        <h3 className="text-sky-200 font-semibold mb-1">
+          ✨ Prefer not to install Ollama? Use Google Gemini instead
+        </h3>
+        <p className="text-sm text-gray-300 leading-relaxed">
+          Use your <strong>own</strong> Google Gemini credential to power AI narration when
+          Ollama isn&apos;t running. Nothing is shared or stored on any server — your key or
+          sign-in stays in this browser and calls go straight to Google from your machine.
+        </p>
+      </div>
+
+      <Checkbox
+        label="Use Google Gemini when Ollama isn't available"
+        checked={creds.geminiFallbackEnabled}
+        onChange={(e) => handleToggleFallback(e.target.checked)}
+      />
+
+      {creds.geminiFallbackEnabled && (
+        <div className="space-y-4 pl-1">
+          {/* Auth-mode selector (Google sign-in only shown when configured). */}
+          <div
+            role="radiogroup"
+            aria-label="Gemini credential type"
+            className="flex flex-wrap gap-4"
+          >
+            <label className="flex items-center gap-2 text-sm text-gray-300 cursor-pointer">
+              <input
+                type="radio"
+                name="gemini-auth-mode"
+                className="accent-amber-500"
+                checked={creds.geminiAuthMode === 'apiKey'}
+                onChange={() => setGeminiAuthMode('apiKey')}
+              />
+              Paste an API key
+            </label>
+            {oauthConfigured && (
+              <label className="flex items-center gap-2 text-sm text-gray-300 cursor-pointer">
+                <input
+                  type="radio"
+                  name="gemini-auth-mode"
+                  className="accent-amber-500"
+                  checked={creds.geminiAuthMode === 'oauth'}
+                  onChange={() => setGeminiAuthMode('oauth')}
+                />
+                Sign in with Google
+              </label>
+            )}
+          </div>
+
+          {creds.geminiAuthMode === 'apiKey' ? (
+            <div className="space-y-2">
+              {hasStoredKey ? (
+                <div className="flex items-center justify-between gap-3">
+                  <span className="text-sm text-emerald-300">
+                    ✓ API key saved (stored locally in this browser)
+                  </span>
+                  <Button onClick={handleClearKey} variant="secondary" size="sm">
+                    Remove key
+                  </Button>
+                </div>
+              ) : (
+                <>
+                  <Input
+                    type="password"
+                    label="Google AI Studio API key"
+                    placeholder="Paste your Gemini API key"
+                    value={apiKeyDraft}
+                    onChange={(e) => setApiKeyDraft(e.target.value)}
+                    autoComplete="off"
+                    helperText="Your key is stored only in this browser and sent only to Google."
+                  />
+                  <div className="flex items-center justify-between gap-3">
+                    <a
+                      href={API_KEY_HELP_URL}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-xs text-sky-300 hover:text-sky-200 underline"
+                    >
+                      Get a free API key →
+                    </a>
+                    <Button onClick={handleSaveKey} variant="action" size="sm">
+                      Save key
+                    </Button>
+                  </div>
+                </>
+              )}
+            </div>
+          ) : (
+            <div className="space-y-2">
+              {creds.oauthAccessToken ? (
+                <div className="flex items-center justify-between gap-3">
+                  <span className="text-sm text-emerald-300">
+                    ✓ Signed in{creds.oauthEmail ? ` as ${creds.oauthEmail}` : ' with Google'}
+                  </span>
+                  <Button onClick={handleSignOut} variant="secondary" size="sm">
+                    Sign out
+                  </Button>
+                </div>
+              ) : (
+                <Button
+                  onClick={handleSignIn}
+                  variant="action"
+                  size="sm"
+                  disabled={signingIn}
+                >
+                  {signingIn ? 'Signing in…' : 'Sign in with Google'}
+                </Button>
+              )}
+              <p className="text-xs text-gray-400">
+                Signs in with your own Google account. The access token is short-lived and
+                kept only in this browser.
+              </p>
+            </div>
+          )}
+
+          {error && (
+            <p className="text-xs text-red-400 font-medium" role="alert">
+              ⚠️ {error}
+            </p>
+          )}
+
+          <p
+            className={`text-xs font-medium ${ready ? 'text-emerald-400' : 'text-amber-300'}`}
+            data-testid="gemini-fallback-status"
+          >
+            {ready
+              ? 'Gemini fallback is ready. AI narration will use Gemini when Ollama is offline.'
+              : 'Add a credential above to activate the Gemini fallback.'}
+          </p>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/components/ui/OllamaDependencyModal.tsx
+++ b/src/components/ui/OllamaDependencyModal.tsx
@@ -36,6 +36,7 @@ import React, { useEffect, useState } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { Button } from './Button';
 import { Checkbox } from './Input';
+import { GeminiFallbackSettings } from './GeminiFallbackSettings';
 import { Z_INDEX } from '../../styles/zIndex';
 import { UI_ID } from '../../styles/uiIds';
 
@@ -259,6 +260,10 @@ export const OllamaDependencyModal: React.FC<OllamaDependencyModalProps> = ({
                           <li>Make sure it is running (it serves on <code className="bg-gray-800 px-1 rounded">localhost:11434</code>), then retry.</li>
                         </ol>
                       </div>
+
+                      {/* Cloud alternative: let players who don't want a local model
+                          supply their own Google Gemini credential instead. */}
+                      <GeminiFallbackSettings />
                     </div>
 
                     {/* Reusable premium Checkbox primitive for tracking user preference */}

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -12,6 +12,16 @@ interface EnvConfig {
   DEV: boolean;
   VITE_ENABLE_DEV_TOOLS: boolean;
   VITE_ENABLE_PORTRAITS: boolean;
+  /**
+   * Public Google OAuth 2.0 client ID used for the optional "Sign in with
+   * Google" path to the Gemini fallback. This is NOT a secret and NOT an API
+   * key — it only identifies this deployment of Aralia to Google's consent
+   * screen. When empty, the OAuth button is hidden and players use the
+   * API-key path instead. Set via VITE_GOOGLE_CLIENT_ID by whoever deploys.
+   */
+  GOOGLE_CLIENT_ID: string;
+  /** OAuth scopes requested when signing in with Google (space-separated). */
+  GOOGLE_OAUTH_SCOPE: string;
 }
 
 // Access raw environment variables
@@ -60,9 +70,38 @@ const getImageApiKey = () => {
   return getApiKey();
 };
 
+const getGoogleClientId = (): string => {
+  if (typeof import.meta !== 'undefined' && import.meta.env && import.meta.env.VITE_GOOGLE_CLIENT_ID) {
+    return import.meta.env.VITE_GOOGLE_CLIENT_ID;
+  }
+  if (typeof process !== 'undefined' && process.env) {
+    return process.env.GOOGLE_CLIENT_ID || process.env.VITE_GOOGLE_CLIENT_ID || '';
+  }
+  return '';
+};
+
+// Default scope for calling the Gemini (Generative Language) API on behalf of
+// the signed-in user. `cloud-platform` authorizes generateContent when the
+// user's Google Cloud project has the Generative Language API enabled; the
+// `userinfo.email` scope is only used to label the connected account in the UI.
+const DEFAULT_GOOGLE_OAUTH_SCOPE =
+  'https://www.googleapis.com/auth/cloud-platform https://www.googleapis.com/auth/userinfo.email';
+
+const getGoogleOAuthScope = (): string => {
+  if (typeof import.meta !== 'undefined' && import.meta.env && import.meta.env.VITE_GOOGLE_OAUTH_SCOPE) {
+    return import.meta.env.VITE_GOOGLE_OAUTH_SCOPE;
+  }
+  if (typeof process !== 'undefined' && process.env && process.env.VITE_GOOGLE_OAUTH_SCOPE) {
+    return process.env.VITE_GOOGLE_OAUTH_SCOPE;
+  }
+  return DEFAULT_GOOGLE_OAUTH_SCOPE;
+};
+
 const RAW_ENV = {
   API_KEY: getApiKey(),
   IMAGE_API_KEY: getImageApiKey(),
+  GOOGLE_CLIENT_ID: getGoogleClientId(),
+  GOOGLE_OAUTH_SCOPE: getGoogleOAuthScope(),
   BASE_URL: (typeof import.meta !== 'undefined' && import.meta.env) ? import.meta.env.BASE_URL : '/',
   DEV: (typeof import.meta !== 'undefined' && import.meta.env) ? import.meta.env.DEV : true,
 
@@ -88,6 +127,8 @@ const normalizedBaseUrl = RAW_ENV.BASE_URL.endsWith('/')
 export const ENV: EnvConfig = {
   API_KEY: RAW_ENV.API_KEY,
   IMAGE_API_KEY: RAW_ENV.IMAGE_API_KEY,
+  GOOGLE_CLIENT_ID: RAW_ENV.GOOGLE_CLIENT_ID,
+  GOOGLE_OAUTH_SCOPE: RAW_ENV.GOOGLE_OAUTH_SCOPE,
   BASE_URL: normalizedBaseUrl,
   DEV: RAW_ENV.DEV,
   // If not explicitly set, fall back to DEV to mirror previous “always on in dev” behavior.

--- a/src/hooks/useAiCredentials.ts
+++ b/src/hooks/useAiCredentials.ts
@@ -1,0 +1,21 @@
+/**
+ * @file src/hooks/useAiCredentials.ts
+ * React binding for the runtime AI credential store. Re-renders when the
+ * player's Gemini fallback settings change.
+ */
+
+import { useSyncExternalStore } from 'react';
+import {
+  AiCredentialsState,
+  getAiCredentials,
+  subscribeAiCredentials,
+} from '../services/ai/aiCredentials';
+
+/** Subscribe to the current AI credential state. */
+export function useAiCredentials(): AiCredentialsState {
+  return useSyncExternalStore(
+    subscribeAiCredentials,
+    getAiCredentials,
+    getAiCredentials,
+  );
+}

--- a/src/services/__tests__/ollamaTextService.fallback.test.ts
+++ b/src/services/__tests__/ollamaTextService.fallback.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock the Ollama client so we can force it "unavailable".
+const generateForTask = vi.fn();
+vi.mock('../ollama/client', () => ({
+  getDefaultClient: () => ({ generateForTask }),
+}));
+
+// Mock the Gemini core text generator used by the fallback path.
+const generateGeminiText = vi.fn();
+vi.mock('../gemini/core', () => ({
+  generateText: (...args: unknown[]) => generateGeminiText(...args),
+}));
+
+// Mock the readiness gate so tests control whether the fallback is active.
+const isGeminiFallbackReady = vi.fn();
+vi.mock('../ai/aiCredentials', () => ({
+  isGeminiFallbackReady: () => isGeminiFallbackReady(),
+}));
+
+import { generateActionOutcome } from '../ollamaTextService';
+
+describe('ollamaTextService Gemini fallback', () => {
+  beforeEach(() => {
+    generateForTask.mockReset();
+    generateGeminiText.mockReset();
+    isGeminiFallbackReady.mockReset();
+  });
+
+  it('uses Ollama when it succeeds (no fallback)', async () => {
+    generateForTask.mockResolvedValue({ ok: true, data: { response: 'local text' }, model: 'llama3' });
+    isGeminiFallbackReady.mockReturnValue(true);
+
+    const result = await generateActionOutcome('action', 'context');
+
+    expect(result.success).toBe(true);
+    expect(result.data?.text).toBe('local text');
+    expect(generateGeminiText).not.toHaveBeenCalled();
+  });
+
+  it('redirects to Gemini when Ollama has no model and fallback is ready', async () => {
+    generateForTask.mockResolvedValue({ ok: false, error: 'NO_MODEL' });
+    isGeminiFallbackReady.mockReturnValue(true);
+    generateGeminiText.mockResolvedValue({
+      data: { text: 'gemini text', promptSent: 'p', rawResponse: 'raw', rateLimitHit: false },
+      error: null,
+    });
+
+    const result = await generateActionOutcome('action', 'context');
+
+    expect(result.success).toBe(true);
+    expect(result.data?.text).toBe('gemini text');
+    expect(generateGeminiText).toHaveBeenCalledTimes(1);
+  });
+
+  it('surfaces the Ollama error when fallback is NOT ready', async () => {
+    generateForTask.mockResolvedValue({ ok: false, error: 'NO_MODEL' });
+    isGeminiFallbackReady.mockReturnValue(false);
+
+    const result = await generateActionOutcome('action', 'context');
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('No Ollama model available');
+    expect(generateGeminiText).not.toHaveBeenCalled();
+  });
+
+  it('redirects to Gemini when the Ollama call throws (server unreachable)', async () => {
+    generateForTask.mockRejectedValue(new Error('fetch failed'));
+    isGeminiFallbackReady.mockReturnValue(true);
+    generateGeminiText.mockResolvedValue({
+      data: { text: 'gemini rescue', promptSent: 'p', rawResponse: 'raw', rateLimitHit: false },
+      error: null,
+    });
+
+    const result = await generateActionOutcome('action', 'context');
+
+    expect(result.success).toBe(true);
+    expect(result.data?.text).toBe('gemini rescue');
+  });
+
+  it('falls back to the Ollama error when Gemini also fails', async () => {
+    generateForTask.mockResolvedValue({ ok: false, error: 'NO_MODEL' });
+    isGeminiFallbackReady.mockReturnValue(true);
+    generateGeminiText.mockResolvedValue({
+      data: null,
+      error: 'Gemini API error',
+      metadata: { promptSent: 'p', rawResponse: 'boom', rateLimitHit: false },
+    });
+
+    const result = await generateActionOutcome('action', 'context');
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('Gemini API error');
+  });
+});

--- a/src/services/ai/__tests__/aiCredentials.test.ts
+++ b/src/services/ai/__tests__/aiCredentials.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  __resetAiCredentialsCacheForTests,
+  clearGeminiApiKey,
+  clearOAuthToken,
+  getActiveGeminiCredential,
+  getAiCredentials,
+  hasGeminiCredential,
+  isGeminiFallbackReady,
+  isOAuthTokenValid,
+  setGeminiApiKey,
+  setGeminiAuthMode,
+  setGeminiFallbackEnabled,
+  setOAuthToken,
+} from '../aiCredentials';
+
+describe('aiCredentials', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    __resetAiCredentialsCacheForTests();
+  });
+
+  it('defaults to disabled with no credential', () => {
+    const state = getAiCredentials();
+    expect(state.geminiFallbackEnabled).toBe(false);
+    expect(state.geminiAuthMode).toBe('apiKey');
+    expect(hasGeminiCredential()).toBe(false);
+    expect(isGeminiFallbackReady()).toBe(false);
+    expect(getActiveGeminiCredential()).toBeNull();
+  });
+
+  it('resolves an API-key credential once saved', () => {
+    setGeminiApiKey('  my-key  ');
+    expect(getAiCredentials().geminiApiKey).toBe('my-key'); // trimmed
+    expect(getActiveGeminiCredential()).toEqual({ mode: 'apiKey', apiKey: 'my-key' });
+    expect(hasGeminiCredential()).toBe(true);
+  });
+
+  it('is only "ready" when opted in AND credentialed', () => {
+    setGeminiApiKey('key');
+    expect(isGeminiFallbackReady()).toBe(false); // not opted in yet
+    setGeminiFallbackEnabled(true);
+    expect(isGeminiFallbackReady()).toBe(true);
+    clearGeminiApiKey();
+    expect(isGeminiFallbackReady()).toBe(false); // opted in but no credential
+  });
+
+  it('persists across a cache reset (localStorage round-trip)', () => {
+    setGeminiFallbackEnabled(true);
+    setGeminiApiKey('persisted');
+    __resetAiCredentialsCacheForTests();
+    const state = getAiCredentials();
+    expect(state.geminiFallbackEnabled).toBe(true);
+    expect(state.geminiApiKey).toBe('persisted');
+  });
+
+  it('treats OAuth tokens as valid only before expiry', () => {
+    const now = 1_000_000;
+    setOAuthToken('tok', 3600, 'me@example.com', now);
+    expect(isOAuthTokenValid(now)).toBe(true);
+    expect(getActiveGeminiCredential(now)).toEqual({ mode: 'oauth', accessToken: 'tok' });
+    // After expiry the credential resolves to null.
+    const afterExpiry = now + 3600 * 1000 + 1;
+    expect(isOAuthTokenValid(afterExpiry)).toBe(false);
+    expect(getActiveGeminiCredential(afterExpiry)).toBeNull();
+  });
+
+  it('setOAuthToken switches auth mode to oauth and clears cleanly', () => {
+    const now = 1_000_000;
+    setOAuthToken('tok', 3600, '', now);
+    expect(getAiCredentials().geminiAuthMode).toBe('oauth');
+    clearOAuthToken();
+    expect(getAiCredentials().oauthAccessToken).toBe('');
+    expect(getActiveGeminiCredential(now)).toBeNull();
+  });
+
+  it('in oauth mode, a saved API key is ignored', () => {
+    setGeminiApiKey('key');
+    setGeminiAuthMode('oauth');
+    // No OAuth token yet → nothing usable even though a key exists.
+    expect(getActiveGeminiCredential()).toBeNull();
+  });
+});

--- a/src/services/ai/aiCredentials.ts
+++ b/src/services/ai/aiCredentials.ts
@@ -1,0 +1,235 @@
+/**
+ * Copyright (c) 2024 Aralia RPG.
+ * Licensed under the MIT License.
+ *
+ * @file src/services/ai/aiCredentials.ts
+ *
+ * Runtime store for the player's OWN Google Gemini credentials.
+ *
+ * Aralia's narrative AI runs on local Ollama by default. When Ollama is not
+ * available, the player may opt in to fall back to Google Gemini using a
+ * credential they supply themselves — either:
+ *   - a Google AI Studio API key (https://aistudio.google.com/apikey), or
+ *   - an OAuth access token obtained by signing in with their own Google
+ *     account (see ./googleOAuth.ts).
+ *
+ * NOTHING is baked into the app: no shared key ships with Aralia. The
+ * credential lives only in the player's browser (localStorage) and is sent
+ * only to Google's API from the player's own machine. This module is the
+ * single source of truth for reading/writing that credential and for deciding
+ * whether the Gemini fallback is "ready".
+ *
+ * SECURITY NOTE: an API key stored in localStorage is readable by any script
+ * running on the page. This is an accepted trade-off for a client-only app
+ * where the key belongs to the player (their key, their quota). Players who
+ * prefer not to persist a key can use the OAuth path, whose token is
+ * short-lived and expires automatically.
+ */
+
+export type GeminiAuthMode = 'apiKey' | 'oauth';
+
+export interface AiCredentialsState {
+  /** Whether to fall back to Gemini when Ollama is unavailable. */
+  geminiFallbackEnabled: boolean;
+  /** Which Gemini credential the player intends to use. */
+  geminiAuthMode: GeminiAuthMode;
+  /** The player's own Google AI Studio API key (plaintext, local only). */
+  geminiApiKey: string;
+  /** The player's own OAuth access token (short-lived). */
+  oauthAccessToken: string;
+  /** Epoch ms when the OAuth token expires (0 when none). */
+  oauthExpiresAt: number;
+  /** Optional display label for the signed-in Google account. */
+  oauthEmail: string;
+}
+
+/** A resolved, currently-usable Gemini credential. */
+export type ActiveGeminiCredential =
+  | { mode: 'apiKey'; apiKey: string }
+  | { mode: 'oauth'; accessToken: string };
+
+const STORAGE_KEY = 'aralia.ai.credentials';
+
+const DEFAULT_STATE: AiCredentialsState = {
+  geminiFallbackEnabled: false,
+  geminiAuthMode: 'apiKey',
+  geminiApiKey: '',
+  oauthAccessToken: '',
+  oauthExpiresAt: 0,
+  oauthEmail: '',
+};
+
+/**
+ * Skew applied when judging OAuth token validity, so a token that is about to
+ * expire mid-request is treated as already expired.
+ */
+const OAUTH_EXPIRY_SKEW_MS = 30_000;
+
+type Listener = () => void;
+const listeners = new Set<Listener>();
+
+let cache: AiCredentialsState | null = null;
+/** Bumped on every mutation so downstream caches (e.g. the AI client) can invalidate. */
+let version = 0;
+
+function hasStorage(): boolean {
+  try {
+    return typeof window !== 'undefined' && !!window.localStorage;
+  } catch {
+    return false;
+  }
+}
+
+function read(): AiCredentialsState {
+  if (cache) return cache;
+  if (!hasStorage()) {
+    cache = { ...DEFAULT_STATE };
+    return cache;
+  }
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) {
+      cache = { ...DEFAULT_STATE };
+    } else {
+      const parsed = JSON.parse(raw) as Partial<AiCredentialsState>;
+      // Merge over defaults so older/partial payloads stay forward-compatible.
+      cache = { ...DEFAULT_STATE, ...parsed };
+    }
+  } catch {
+    cache = { ...DEFAULT_STATE };
+  }
+  return cache;
+}
+
+function write(next: AiCredentialsState): void {
+  cache = next;
+  version += 1;
+  if (hasStorage()) {
+    try {
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+    } catch {
+      // Storage may be full or blocked (private mode). The in-memory cache
+      // still reflects the change for the current session.
+    }
+  }
+  for (const listener of listeners) {
+    listener();
+  }
+}
+
+/** Returns a snapshot of the current credentials state. */
+export function getAiCredentials(): AiCredentialsState {
+  return read();
+}
+
+/**
+ * Monotonic version counter. Consumers that cache a derived object (like the
+ * GoogleGenAI client) compare this to know when to rebuild.
+ */
+export function getCredentialsVersion(): number {
+  read();
+  return version;
+}
+
+/** Subscribe to credential changes. Returns an unsubscribe function. */
+export function subscribeAiCredentials(listener: Listener): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+function update(patch: Partial<AiCredentialsState>): void {
+  write({ ...read(), ...patch });
+}
+
+export function setGeminiFallbackEnabled(enabled: boolean): void {
+  update({ geminiFallbackEnabled: enabled });
+}
+
+export function setGeminiAuthMode(mode: GeminiAuthMode): void {
+  update({ geminiAuthMode: mode });
+}
+
+export function setGeminiApiKey(apiKey: string): void {
+  update({ geminiApiKey: apiKey.trim() });
+}
+
+export function clearGeminiApiKey(): void {
+  update({ geminiApiKey: '' });
+}
+
+/**
+ * Store an OAuth access token obtained from the player's own Google sign-in.
+ * @param accessToken The bearer token.
+ * @param expiresInSeconds Lifetime in seconds as reported by Google.
+ * @param email Optional account label for display.
+ * @param nowMs Injectable clock for tests.
+ */
+export function setOAuthToken(
+  accessToken: string,
+  expiresInSeconds: number,
+  email = '',
+  nowMs: number = Date.now(),
+): void {
+  update({
+    oauthAccessToken: accessToken,
+    oauthExpiresAt: nowMs + expiresInSeconds * 1000,
+    oauthEmail: email,
+    geminiAuthMode: 'oauth',
+  });
+}
+
+export function clearOAuthToken(): void {
+  update({ oauthAccessToken: '', oauthExpiresAt: 0, oauthEmail: '' });
+}
+
+/** True when a stored OAuth token exists and has not (nearly) expired. */
+export function isOAuthTokenValid(nowMs: number = Date.now()): boolean {
+  const state = read();
+  return (
+    !!state.oauthAccessToken &&
+    state.oauthExpiresAt - OAUTH_EXPIRY_SKEW_MS > nowMs
+  );
+}
+
+/**
+ * Resolve the credential the player has actually configured for the selected
+ * auth mode, or null if nothing usable is available. OAuth tokens that have
+ * expired resolve to null so the caller can prompt for re-authentication.
+ */
+export function getActiveGeminiCredential(
+  nowMs: number = Date.now(),
+): ActiveGeminiCredential | null {
+  const state = read();
+  if (state.geminiAuthMode === 'oauth') {
+    if (isOAuthTokenValid(nowMs)) {
+      return { mode: 'oauth', accessToken: state.oauthAccessToken };
+    }
+    return null;
+  }
+  if (state.geminiApiKey) {
+    return { mode: 'apiKey', apiKey: state.geminiApiKey };
+  }
+  return null;
+}
+
+/** True when any usable Gemini credential is configured, regardless of opt-in. */
+export function hasGeminiCredential(nowMs: number = Date.now()): boolean {
+  return getActiveGeminiCredential(nowMs) !== null;
+}
+
+/**
+ * True when the player has opted in to the Gemini fallback AND supplied a
+ * usable credential for it. This is the gate the narrative services check
+ * before redirecting an unavailable-Ollama call to Gemini.
+ */
+export function isGeminiFallbackReady(nowMs: number = Date.now()): boolean {
+  return read().geminiFallbackEnabled && hasGeminiCredential(nowMs);
+}
+
+/** Test-only: reset the in-memory cache so the next read re-hydrates. */
+export function __resetAiCredentialsCacheForTests(): void {
+  cache = null;
+  version = 0;
+}

--- a/src/services/ai/googleOAuth.ts
+++ b/src/services/ai/googleOAuth.ts
@@ -1,0 +1,165 @@
+/**
+ * Copyright (c) 2024 Aralia RPG.
+ * Licensed under the MIT License.
+ *
+ * @file src/services/ai/googleOAuth.ts
+ *
+ * Thin wrapper around Google Identity Services (GIS) for the optional
+ * "Sign in with Google" path to the Gemini fallback.
+ *
+ * The player signs in with THEIR OWN Google account and Aralia receives a
+ * short-lived OAuth access token scoped to the Generative Language API. The
+ * token belongs to the player (their account, their quota) and is stored only
+ * in their browser (see ./aiCredentials.ts). Aralia never sees the player's
+ * password and no shared credential ships with the app.
+ *
+ * This flow requires a PUBLIC OAuth client ID (ENV.GOOGLE_CLIENT_ID) registered
+ * by whoever deploys Aralia. A client ID is not a secret and not an API key —
+ * it merely identifies the app to Google's consent screen. When no client ID
+ * is configured, `isGoogleOAuthConfigured()` returns false and callers should
+ * fall back to the API-key path.
+ */
+
+import { ENV } from '../../config/env';
+import { setOAuthToken } from './aiCredentials';
+
+const GIS_SCRIPT_SRC = 'https://accounts.google.com/gsi/client';
+
+/** Minimal shape of the GIS token response we consume. */
+interface GisTokenResponse {
+  access_token?: string;
+  expires_in?: number;
+  scope?: string;
+  error?: string;
+  error_description?: string;
+}
+
+interface GisTokenClient {
+  requestAccessToken: (overrides?: { prompt?: string }) => void;
+}
+
+interface GoogleOAuth2 {
+  initTokenClient: (config: {
+    client_id: string;
+    scope: string;
+    callback: (response: GisTokenResponse) => void;
+    error_callback?: (error: { type?: string; message?: string }) => void;
+  }) => GisTokenClient;
+}
+
+declare global {
+  interface Window {
+    google?: {
+      accounts?: {
+        oauth2?: GoogleOAuth2;
+      };
+    };
+  }
+}
+
+/** Whether a Google OAuth client ID is configured for this deployment. */
+export function isGoogleOAuthConfigured(): boolean {
+  return !!ENV.GOOGLE_CLIENT_ID;
+}
+
+let scriptPromise: Promise<void> | null = null;
+
+/** Lazily load the GIS client script exactly once. */
+function loadGisScript(): Promise<void> {
+  if (typeof window === 'undefined' || typeof document === 'undefined') {
+    return Promise.reject(new Error('Google sign-in is only available in the browser.'));
+  }
+  if (window.google?.accounts?.oauth2) {
+    return Promise.resolve();
+  }
+  if (scriptPromise) return scriptPromise;
+
+  scriptPromise = new Promise<void>((resolve, reject) => {
+    const existing = document.querySelector<HTMLScriptElement>(`script[src="${GIS_SCRIPT_SRC}"]`);
+    if (existing) {
+      existing.addEventListener('load', () => resolve());
+      existing.addEventListener('error', () => reject(new Error('Failed to load Google sign-in script.')));
+      // If it already loaded before we attached listeners, resolve on next tick.
+      if (window.google?.accounts?.oauth2) resolve();
+      return;
+    }
+    const script = document.createElement('script');
+    script.src = GIS_SCRIPT_SRC;
+    script.async = true;
+    script.defer = true;
+    script.onload = () => resolve();
+    script.onerror = () => {
+      scriptPromise = null;
+      reject(new Error('Failed to load Google sign-in script.'));
+    };
+    document.head.appendChild(script);
+  });
+  return scriptPromise;
+}
+
+/**
+ * Best-effort lookup of the signed-in account's email for display only.
+ * Requires the userinfo.email scope; failures are non-fatal.
+ */
+async function fetchUserEmail(accessToken: string): Promise<string> {
+  try {
+    const res = await fetch('https://www.googleapis.com/oauth2/v3/userinfo', {
+      headers: { Authorization: `Bearer ${accessToken}` },
+    });
+    if (!res.ok) return '';
+    const data = (await res.json()) as { email?: string };
+    return data.email ?? '';
+  } catch {
+    return '';
+  }
+}
+
+/**
+ * Run the interactive Google sign-in / consent flow and persist the resulting
+ * access token via the credentials store. Resolves with the stored token, or
+ * rejects if the flow fails or is dismissed by the user.
+ */
+export async function signInWithGoogle(): Promise<{ accessToken: string; email: string; expiresIn: number }> {
+  if (!isGoogleOAuthConfigured()) {
+    throw new Error('Google OAuth is not configured for this deployment (missing client ID).');
+  }
+  await loadGisScript();
+
+  const oauth2 = window.google?.accounts?.oauth2;
+  if (!oauth2) {
+    throw new Error('Google sign-in failed to initialize.');
+  }
+
+  const response = await new Promise<GisTokenResponse>((resolve, reject) => {
+    let settled = false;
+    const tokenClient = oauth2.initTokenClient({
+      client_id: ENV.GOOGLE_CLIENT_ID,
+      scope: ENV.GOOGLE_OAUTH_SCOPE,
+      callback: (resp) => {
+        if (settled) return;
+        settled = true;
+        if (resp.error) {
+          reject(new Error(resp.error_description || resp.error));
+        } else {
+          resolve(resp);
+        }
+      },
+      error_callback: (err) => {
+        if (settled) return;
+        settled = true;
+        reject(new Error(err.message || err.type || 'Google sign-in was cancelled.'));
+      },
+    });
+    tokenClient.requestAccessToken({ prompt: '' });
+  });
+
+  const accessToken = response.access_token;
+  if (!accessToken) {
+    throw new Error('Google sign-in did not return an access token.');
+  }
+  const expiresIn = response.expires_in ?? 3600;
+  const email = await fetchUserEmail(accessToken);
+
+  setOAuthToken(accessToken, expiresIn, email);
+  return { accessToken, email, expiresIn };
+}

--- a/src/services/ai/oauthGeminiClient.ts
+++ b/src/services/ai/oauthGeminiClient.ts
@@ -1,0 +1,170 @@
+/**
+ * Copyright (c) 2024 Aralia RPG.
+ * Licensed under the MIT License.
+ *
+ * @file src/services/ai/oauthGeminiClient.ts
+ *
+ * Minimal REST adapter that lets the app call the Gemini (Generative Language)
+ * API with an OAuth bearer token instead of an API key.
+ *
+ * WHY THIS EXISTS: the @google/genai browser SDK hard-requires an `apiKey` in
+ * its constructor, so it cannot be used for the "Sign in with Google" path
+ * where the player authenticates with their own OAuth token. This adapter
+ * exposes just the surface the app consumes — `client.models.generateContent`
+ * — so it can be dropped in wherever the SDK client is used (see aiClient.ts).
+ *
+ * It translates the SDK-style request `{ model, contents, config }` into the
+ * REST body the endpoint expects, sends the token as `Authorization: Bearer`,
+ * and returns a response object shaped like the SDK's GenerateContentResponse
+ * (exposing `.text` plus the raw `candidates`) so existing callers work
+ * unchanged.
+ */
+
+const GENAI_BASE_URL = 'https://generativelanguage.googleapis.com';
+const GENAI_API_VERSION = 'v1beta';
+
+/** The subset of an SDK generateContent request that callers in this app use. */
+interface GenerateContentArgs {
+  model: string;
+  // The SDK accepts string | Content | Content[]; this app passes a string.
+  contents: unknown;
+  config?: Record<string, unknown>;
+}
+
+/** Response wrapper mirroring the fields the app reads off the SDK response. */
+interface AdapterResponse {
+  readonly text: string | undefined;
+  candidates?: unknown;
+  promptFeedback?: unknown;
+  usageMetadata?: unknown;
+}
+
+/** Config keys that belong under REST `generationConfig` rather than top-level. */
+const GENERATION_CONFIG_KEYS = new Set([
+  'temperature',
+  'topK',
+  'topP',
+  'candidateCount',
+  'maxOutputTokens',
+  'stopSequences',
+  'responseMimeType',
+  'responseSchema',
+  'thinkingConfig',
+  'responseModalities',
+  'speechConfig',
+  'seed',
+  'presencePenalty',
+  'frequencyPenalty',
+]);
+
+function normalizeContents(contents: unknown): unknown {
+  if (typeof contents === 'string') {
+    return [{ role: 'user', parts: [{ text: contents }] }];
+  }
+  // Already a Content or Content[]; pass through and let the API validate.
+  return Array.isArray(contents) ? contents : [contents];
+}
+
+function normalizeSystemInstruction(value: unknown): unknown {
+  if (value == null) return undefined;
+  if (typeof value === 'string') {
+    return { parts: [{ text: value }] };
+  }
+  return value;
+}
+
+function buildRequestBody(args: GenerateContentArgs): Record<string, unknown> {
+  const body: Record<string, unknown> = {
+    contents: normalizeContents(args.contents),
+  };
+
+  const config = args.config ?? {};
+  const generationConfig: Record<string, unknown> = {};
+
+  for (const [key, val] of Object.entries(config)) {
+    if (val === undefined) continue;
+    if (key === 'systemInstruction') {
+      const sys = normalizeSystemInstruction(val);
+      if (sys) body.systemInstruction = sys;
+    } else if (key === 'tools' || key === 'toolConfig' || key === 'safetySettings') {
+      body[key] = val;
+    } else if (GENERATION_CONFIG_KEYS.has(key)) {
+      generationConfig[key] = val;
+    }
+    // Unknown keys are dropped rather than risking a 400 from the REST API.
+  }
+
+  if (Object.keys(generationConfig).length > 0) {
+    body.generationConfig = generationConfig;
+  }
+  return body;
+}
+
+function extractText(json: {
+  candidates?: Array<{ content?: { parts?: Array<{ text?: string }> } }>;
+}): string | undefined {
+  const parts = json.candidates?.[0]?.content?.parts;
+  if (!parts || parts.length === 0) return undefined;
+  const text = parts
+    .map((p) => (typeof p.text === 'string' ? p.text : ''))
+    .join('');
+  return text.length > 0 ? text : undefined;
+}
+
+/**
+ * Build a minimal client that calls Gemini with an OAuth bearer token.
+ * @param getAccessToken Lazily returns the current token, so token refreshes
+ *   are picked up without rebuilding the client.
+ */
+export function createOAuthGeminiClient(getAccessToken: () => string) {
+  async function generateContent(args: GenerateContentArgs): Promise<AdapterResponse> {
+    const token = getAccessToken();
+    if (!token) {
+      throw new Error('No Google OAuth token available. Please sign in with Google again.');
+    }
+
+    const url = `${GENAI_BASE_URL}/${GENAI_API_VERSION}/models/${args.model}:generateContent`;
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(buildRequestBody(args)),
+    });
+
+    if (!res.ok) {
+      let detail = '';
+      try {
+        detail = await res.text();
+      } catch {
+        /* ignore */
+      }
+      // Preserve the HTTP status code in the message so the shared Gemini error
+      // handling (which sniffs for "429"/"503") keeps working via OAuth too.
+      const err = new Error(`Gemini API error ${res.status}: ${res.statusText}${detail ? ` — ${detail}` : ''}`);
+      (err as Error & { status?: number }).status = res.status;
+      throw err;
+    }
+
+    const json = (await res.json()) as {
+      candidates?: Array<{ content?: { parts?: Array<{ text?: string }> } }>;
+      promptFeedback?: unknown;
+      usageMetadata?: unknown;
+    };
+
+    const text = extractText(json);
+    return {
+      text,
+      candidates: json.candidates,
+      promptFeedback: json.promptFeedback,
+      usageMetadata: json.usageMetadata,
+    };
+  }
+
+  return {
+    models: { generateContent },
+  };
+}
+
+export type OAuthGeminiClient = ReturnType<typeof createOAuthGeminiClient>;

--- a/src/services/aiClient.ts
+++ b/src/services/aiClient.ts
@@ -3,79 +3,140 @@
  * Licensed under the MIT License.
  *
  * @file aiClient.ts
- * This service module centralizes the initialization of the GoogleGenAI client.
- * It ensures the API key is present and exports a single, shared AI client instance
- * for use by other services (geminiService, ttsService).
+ * This service module centralizes access to the Google Gemini client.
  *
- * Pattern: Singleton Proxy
- * We use a Proxy pattern to allow safe exports even when the client isn't initialized.
- * This prevents runtime crashes during static analysis or module loading if the API key is missing.
+ * Credential resolution (highest priority first):
+ *   1. The player's OWN runtime credential — an API key they pasted or an OAuth
+ *      token from signing in with Google (see ./ai/aiCredentials.ts). This is
+ *      the primary path: nothing is baked into the app, and the credential
+ *      lives only in the player's browser.
+ *   2. A build-time API key (ENV.API_KEY) for self-hosted deployments that
+ *      choose to bake one in. Optional — most deployments leave it unset.
+ *
+ * All Gemini-backed services (gemini/core, gemini/encounters, ttsService)
+ * import the shared `ai` proxy and `isAiEnabled()` from here, so switching
+ * credentials at runtime transparently reroutes every one of them.
+ *
+ * Pattern: Singleton Proxy. We use a Proxy so `ai` can be exported safely even
+ * when no credential is configured; property access throws a descriptive error
+ * only if actually used without a credential.
  */
 import { GoogleGenAI } from "@google/genai";
 import { ENV } from "../config/env";
+import {
+  getActiveGeminiCredential,
+  getCredentialsVersion,
+  hasGeminiCredential,
+} from "./ai/aiCredentials";
+import { createOAuthGeminiClient } from "./ai/oauthGeminiClient";
 
-// Ensure API_KEY is available from the environment.
-let aiInstance: GoogleGenAI | null = null;
+/**
+ * The slice of the GoogleGenAI surface the app actually uses. Kept structurally
+ * loose so both the real SDK client and the OAuth REST adapter satisfy it and
+ * are interchangeable. Consumers still see the precise SDK types via the `ai`
+ * proxy, which is typed as GoogleGenAI.
+ */
+interface ActiveAiClient {
+  models: {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    generateContent: (...args: any[]) => Promise<any>;
+  };
+}
 
-if (!ENV.API_KEY) {
-  const errorMessage =
-    "Gemini API Key (API_KEY) is not set in the environment. " +
-    "AI features will not work, and the application cannot initialize the AI client.";
-  console.error(errorMessage);
-  // Do not throw here to prevent app crash. Instead, aiInstance remains null.
+// Optional build-time instance for deployments that bake in a key.
+let buildTimeInstance: GoogleGenAI | null = null;
+if (ENV.API_KEY) {
+  buildTimeInstance = new GoogleGenAI({ apiKey: ENV.API_KEY });
 } else {
-    aiInstance = new GoogleGenAI({ apiKey: ENV.API_KEY });
+  // Not an error: the app runs on local Ollama by default, and players can
+  // supply their own Gemini credential at runtime for the fallback.
+  console.info(
+    "aiClient: no build-time Gemini API key. Gemini features use the player's own runtime credential (API key or Google sign-in) when configured."
+  );
+}
+
+// Runtime client cache. Rebuilt when the active credential changes.
+let cachedClient: ActiveAiClient | null = null;
+let cachedFingerprint = "";
+
+/** Lazily read the current OAuth token for the REST adapter. */
+function currentOAuthToken(): string {
+  const cred = getActiveGeminiCredential();
+  return cred?.mode === "oauth" ? cred.accessToken : "";
 }
 
 /**
- * Checks if the AI client is initialized and available for use.
- * @returns {boolean} True if the AI client is ready, false otherwise.
+ * Resolve the client backing the current credential, or the build-time
+ * instance, or null when nothing is configured.
+ */
+function resolveActiveClient(): ActiveAiClient | null {
+  const cred = getActiveGeminiCredential();
+  if (!cred) {
+    return buildTimeInstance;
+  }
+
+  // Fingerprint API-key clients by the key (so pasting a new key rebuilds);
+  // OAuth clients read the token lazily, so a plain 'oauth' tag is enough and
+  // token refreshes don't force a rebuild.
+  const fingerprint =
+    cred.mode === "apiKey" ? `key:${cred.apiKey}` : "oauth";
+  const versioned = `${getCredentialsVersion()}:${fingerprint}`;
+
+  if (cachedClient && cachedFingerprint === versioned) {
+    return cachedClient;
+  }
+
+  cachedClient =
+    cred.mode === "apiKey"
+      ? new GoogleGenAI({ apiKey: cred.apiKey })
+      : createOAuthGeminiClient(currentOAuthToken);
+  cachedFingerprint = versioned;
+  return cachedClient;
+}
+
+/**
+ * Checks if a usable Gemini credential is available (runtime or build-time).
+ * @returns {boolean} True if Gemini calls can be made.
  */
 export const isAiEnabled = (): boolean => {
-  return !!aiInstance;
+  return hasGeminiCredential() || !!buildTimeInstance;
 };
 
 /**
- * Returns the initialized AI client, or throws an error if it is not available.
- * Use this for safe access to the client.
- * @returns {GoogleGenAI} The initialized GoogleGenAI client.
- * @throws {Error} If the AI client is not initialized (e.g., missing API key).
+ * Returns the active AI client, or throws if none is configured.
+ * @throws {Error} If no credential is available.
  */
-export const getAiClient = (): GoogleGenAI => {
-  if (!aiInstance) {
-    throw new Error("AI client is not initialized. Check your API_KEY configuration.");
+export const getAiClient = (): ActiveAiClient => {
+  const client = resolveActiveClient();
+  if (!client) {
+    throw new Error(
+      "AI client is not initialized. Provide a Gemini API key or sign in with Google in the AI settings."
+    );
   }
-  return aiInstance;
+  return client;
 };
 
 /**
- * The shared GoogleGenAI client instance.
- * Protected by a Proxy to throw descriptive errors if accessed when uninitialized,
- * preventing 'Cannot read properties of null' runtime crashes.
+ * The shared Gemini client instance, resolved dynamically per access so it
+ * always reflects the current runtime credential.
  *
  * @example
- * // If initialized:
  * await ai.models.generateContent(...)
- *
- * // If NOT initialized:
- * // Throws: "Gemini API Client accessed but not initialized..."
  */
 export const ai = new Proxy({} as GoogleGenAI, {
   get: (target, prop) => {
-    if (aiInstance) {
-      return Reflect.get(aiInstance, prop);
+    const client = resolveActiveClient();
+    if (client) {
+      return Reflect.get(client as object, prop);
     }
-    if (prop === 'getGenerativeModel') {
-      return () => {
-        throw new Error("Gemini API Client accessed but not initialized. Check API_KEY.");
-      };
-    }
-    // Allow checking constructor/prototype without throwing, sometimes used by testing/frameworks
-    if (prop === 'constructor' || prop === 'prototype') {
+    // Allow constructor/prototype probing without throwing (used by tooling).
+    if (prop === "constructor" || prop === "prototype") {
       return Reflect.get(target, prop);
     }
-
-    // Throw descriptive error for any property access if not initialized
-    throw new Error(`Gemini API Client accessed but not initialized. Accessing '${String(prop)}' failed. Check API_KEY.`);
-  }
+    throw new Error(
+      `Gemini API Client accessed but not initialized. Accessing '${String(
+        prop
+      )}' failed. Provide a Gemini API key or sign in with Google.`
+    );
+  },
 });

--- a/src/services/ollamaTextService.ts
+++ b/src/services/ollamaTextService.ts
@@ -9,6 +9,8 @@
 
 import { getDefaultClient } from './ollama/client';
 import type { OllamaResult, TaskType, ModelParams } from './ollama';
+import { isGeminiFallbackReady } from './ai/aiCredentials';
+import { generateText as generateGeminiText } from './gemini/core';
 
 // Types matching Gemini service interface
 export interface OllamaTextData {
@@ -30,11 +32,72 @@ export interface StandardizedResult<T> {
 }
 
 /**
+ * When Ollama cannot serve a narrative call, redirect it to Google Gemini —
+ * but only if the player has opted in and supplied their OWN credential (API
+ * key or Google sign-in; see ./ai/aiCredentials.ts). Returns a mapped
+ * StandardizedResult on success, or null when the fallback is not available or
+ * itself fails, so the caller can surface the original Ollama error.
+ *
+ * The same `prompt` + `systemInstruction` are forwarded verbatim, so each
+ * task keeps its tuned wording regardless of which backend answers.
+ */
+async function tryGeminiFallback(
+  taskType: TaskType,
+  prompt: string,
+  systemInstruction: string | undefined
+): Promise<StandardizedResult<OllamaTextData> | null> {
+  if (!isGeminiFallbackReady()) {
+    return null;
+  }
+
+  const gemini = await generateGeminiText(
+    prompt,
+    systemInstruction,
+    false,
+    `ollamaFallback:${taskType}`
+  );
+
+  if (gemini.data?.text) {
+    return {
+      success: true,
+      data: {
+        text: gemini.data.text.trim(),
+        promptSent: prompt,
+        rawResponse: gemini.data.rawResponse,
+        rateLimitHit: gemini.data.rateLimitHit
+      },
+      metadata: {
+        promptSent: prompt,
+        rawResponse: gemini.data.rawResponse,
+        rateLimitHit: gemini.data.rateLimitHit
+      }
+    };
+  }
+
+  // Gemini was configured but did not produce usable text; report its error so
+  // it is visible in the log, but let the caller decide what to show.
+  return {
+    success: false,
+    error: gemini.error || 'Gemini fallback produced no text',
+    data: null,
+    metadata: {
+      promptSent: prompt,
+      rawResponse: gemini.metadata?.rawResponse || gemini.error || 'Gemini fallback failed',
+      rateLimitHit: gemini.metadata?.rateLimitHit ?? false
+    }
+  };
+}
+
+/**
  * Generate text using Ollama with standardized error handling.
  *
  * Routes by TaskType so each narrative call gets the model/params matched to
  * its category (see docs/ai/local-llm-model-routing.md). Per-call overrides
  * are accepted for cases where the caller needs to tune sampling.
+ *
+ * If Ollama is unavailable (no local model / network error) and the player has
+ * enabled the Gemini fallback with their own credential, the call is
+ * transparently redirected to Gemini instead.
  */
 async function generateText(
   taskType: TaskType,
@@ -57,6 +120,13 @@ async function generateText(
     });
 
     if (!result.ok) {
+      // Ollama could not serve the request — redirect to Gemini if the player
+      // configured that fallback; otherwise surface the Ollama error.
+      const fallback = await tryGeminiFallback(taskType, prompt, systemInstruction);
+      if (fallback) {
+        return fallback;
+      }
+
       const errorMessage = result.error === 'NO_MODEL'
         ? 'No Ollama model available'
         : result.error;
@@ -85,9 +155,16 @@ async function generateText(
         rateLimitHit: false
       }
     };
-  } catch (error: any) {
     // DEBT: Cast error to any to access message property on unknown catch variable.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } catch (error: any) {
+    // A thrown error usually means Ollama is unreachable; try Gemini before
+    // giving up so an offline local server doesn't block narrative generation.
+    const fallback = await tryGeminiFallback(taskType, prompt, systemInstruction);
+    if (fallback) {
+      return fallback;
+    }
+
     return {
       success: false,
       error: error.message || 'Unknown error in Ollama text generation',


### PR DESCRIPTION
## Summary

Adds an optional Google Gemini fallback for AI narration when local Ollama is unavailable. Players can supply their own credential—either a Google AI Studio API key or by signing in with their own Google account via OAuth—without any shared key being baked into the app. The credential lives only in the player's browser and is sent directly to Google from their machine.

## Key Changes

- **Credential management** (`src/services/ai/aiCredentials.ts`): New runtime store for the player's Gemini credential (API key or OAuth token). Handles persistence to localStorage, expiry validation, and subscription-based updates. Provides a single source of truth for whether the Gemini fallback is "ready" (opted in + credentialed).

- **OAuth integration** (`src/services/ai/googleOAuth.ts`): Thin wrapper around Google Identity Services (GIS) for the optional "Sign in with Google" flow. Loads the GIS script lazily, manages the token exchange, and fetches the user's email for display. Requires a public OAuth client ID configured at deployment time.

- **OAuth REST adapter** (`src/services/ai/oauthGeminiClient.ts`): Minimal REST client that calls the Gemini API with an OAuth bearer token instead of an API key. Translates SDK-style requests into REST payloads and returns responses shaped like the SDK's `GenerateContentResponse`, making it a drop-in replacement for the GoogleGenAI SDK client.

- **Client resolution** (`src/services/aiClient.ts`): Refactored to resolve credentials in priority order: player's runtime credential (API key or OAuth) → build-time `GEMINI_API_KEY` → null. Caches the active client and rebuilds only when the credential changes. Exports a proxy that safely handles missing credentials.

- **Fallback routing** (`src/services/ollamaTextService.ts`): When an Ollama call fails (no model / unreachable), checks `isGeminiFallbackReady()` and transparently redirects to Gemini with the same prompt + system instruction if the player has opted in and supplied a credential.

- **UI component** (`src/components/ui/GeminiFallbackSettings.tsx`): Settings panel shown in the Ollama Dependency modal. Lets players toggle the fallback, choose between API-key and OAuth authentication, paste/manage their key, or sign in with Google. Displays credential status and helpful links.

- **React hook** (`src/hooks/useAiCredentials.ts`): `useSyncExternalStore` binding for the credential store, enabling components to subscribe to changes.

- **Environment configuration** (`src/config/env.ts`, `.env.example`): Added `VITE_GOOGLE_CLIENT_ID` and `GOOGLE_OAUTH_SCOPE` for optional OAuth deployment configuration.

- **Tests**: Comprehensive test coverage for credential storage, OAuth token validation, and fallback routing behavior.

- **Documentation** (`docs/ai/gemini-fallback.md`): Explains the feature, authentication options, how the redirect works, and deployment configuration.

## Notable Implementation Details

- **No shared credentials**: The app ships with no API key or OAuth secret. Players supply their own at runtime, and the credential is stored only in localStorage.
- **Transparent fallback**: The redirect happens at the `ollamaTextService` level, so all narrative services (encounters, action outcomes, oracle, etc.) automatically benefit without code changes.
- **Lazy OAuth token reading**: The OAuth REST adapter reads the token on each request, so token refreshes (if implemented) are picked up without rebuilding the client.
- **Forward compatibility**: Credential state merges over defaults, so older/partial payloads in localStorage stay compatible.
- **Expiry skew**: OAuth tokens are treated as expired 30 seconds before their actual expiry to avoid mid-request failures.

https://claude.ai/code/session_01LwK1rPCvQm4Cbrar5eRbGE